### PR TITLE
Ensure the same date format everywhere

### DIFF
--- a/src/component/application/application-edit-component.js
+++ b/src/component/application/application-edit-component.js
@@ -10,6 +10,7 @@ import {
     Switch,
 } from 'react-mdl';
 import { HeaderTitle, ExternalIconLink, shorten } from '../common';
+import { formatFullDateTime } from '../common/util';
 
 class StatefulTextfield extends Component {
     constructor (props) {
@@ -121,7 +122,7 @@ class ClientApplications extends PureComponent {
                             <ListItemContent
                                 icon="timeline"
                                 subtitle={
-                                    <span>{clientIp} last seen at <small>{new Date(lastSeen).toLocaleString('nb-NO')}</small></span>
+                                    <span>{clientIp} last seen at <small>{formatFullDateTime(lastSeen)}</small></span>
                                 }>
                                 {instanceId}
                             </ListItemContent>

--- a/src/component/common/util.js
+++ b/src/component/common/util.js
@@ -1,0 +1,3 @@
+const dateTimeOptions = { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' };
+
+export const formatFullDateTime = v => new Date(v).toLocaleString('nb-NO', dateTimeOptions);

--- a/src/component/feature/view-component.jsx
+++ b/src/component/feature/view-component.jsx
@@ -5,6 +5,7 @@ import { hashHistory, Link } from 'react-router';
 import HistoryComponent from '../history/history-list-toggle-container';
 import MetricComponent from './metric-container';
 import EditFeatureToggle from './form-edit-container.jsx';
+import { formatFullDateTime } from '../common/util';
 
 const TABS = {
     view: 0,
@@ -80,7 +81,7 @@ export default class ViewFeatureToggleComponent extends React.Component {
             <div>
                 <h4>{featureToggle.name} <small>{featureToggle.enabled ? 'is enabled' : 'is disabled'}</small>
                     <small style={{ float: 'right', lineHeight: '38px' }}>
-                        Created {(new Date(featureToggle.createdAt)).toLocaleString('nb-NO')}
+                        Created {formatFullDateTime(featureToggle.createdAt)}
                     </small>
                 </h4>
                 <div className="mdl-color-text--grey"><small>{featureToggle.description}</small></div>

--- a/src/component/history/history-list-component.jsx
+++ b/src/component/history/history-list-component.jsx
@@ -3,12 +3,9 @@ import HistoryItemDiff from './history-item-diff';
 import HistoryItemJson from './history-item-json';
 import { Table, TableHeader } from 'react-mdl';
 import { HeaderTitle, SwitchWithLabel } from '../common';
+import { formatFullDateTime } from '../common/util';
 
 import style from './history.scss';
-
-const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' };
-
-const formatDate = v => (new Date(v)).toLocaleString('nb-NO', dateOptions);
 
 class HistoryList extends Component {
 
@@ -40,7 +37,7 @@ class HistoryList extends Component {
                 <TableHeader name="type">Type</TableHeader>
                 <TableHeader name="createdBy">User</TableHeader>
                 <TableHeader name="diff">Diff</TableHeader>
-                <TableHeader numeric name="createdAt" cellFormatter={formatDate}>Time</TableHeader>
+                <TableHeader numeric name="createdAt" cellFormatter={formatFullDateTime}>Time</TableHeader>
             </Table>);
         }
 


### PR DESCRIPTION
Avoid e.g.

![image](https://cloud.githubusercontent.com/assets/1404810/21715941/9ed673bc-d407-11e6-9762-cce7b844b5ea.png)
