### PR TITLE
increase slider thumb touch target

### DIFF
--- a/src/component/feature/form/strategy-input-percentage.jsx
+++ b/src/component/feature/form/strategy-input-percentage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Slider } from 'react-mdl';
+import styles from './strategy.scss';
 
 const labelStyle = {
     margin: '20px 0',
@@ -11,6 +12,6 @@ const labelStyle = {
 export default ({ name, value, onChange }) => (
     <div style={{ marginBottom: '20px' }}>
         <div style={labelStyle}>{name}: {value}%</div>
-        <Slider min={0} max={100} defaultValue={value} value={value} onChange={onChange} label={name} />
+        <Slider min={0} max={100} defaultValue={value} value={value} onChange={onChange} label={name} className={styles.sliderThumb}/>
     </div>
 );

--- a/src/component/feature/form/strategy.scss
+++ b/src/component/feature/form/strategy.scss
@@ -56,3 +56,8 @@
     display: inline-block;
     vertical-align: bottom;
 }
+
+.sliderThumb::-webkit-slider-thumb {
+    margin-top: 12px;
+    margin-bottom: 12px;
+}


### PR DESCRIPTION
Trying to increase the touch target size as requested in https://github.com/Unleash/unleash/issues/254

Not really sure this works on iOS, though. Needs more work.
