### PR TITLE
Allow underscores in name validation

### DIFF
--- a/src/component/strategies/add-strategy.jsx
+++ b/src/component/strategies/add-strategy.jsx
@@ -128,7 +128,7 @@ class AddStrategy extends Component {
                             name="name"
                             required
                             disabled={editmode}
-                            pattern="^[0-9a-zA-Z\.\-]+$"
+                            pattern="^[0-9a-zA-Z\.\-\_]+$"
                             onChange={({ target }) => setValue('name', trim(target.value))}
                             value={input.name}
                         />


### PR DESCRIPTION
This PR adds support for underscores in strategy names, allowing for const style naming conventions (`FOO_BAR`).

See related PR in `Unleash/unleash` - https://github.com/Unleash/unleash/pull/267

<img width="1121" alt="create feature toggle with underscores" src="https://user-images.githubusercontent.com/1551632/30576386-e6061c4e-9d4a-11e7-8e19-e5fd46561eb6.png">
