### PR TITLE
fix(navigation): signout more visible

### DIFF
--- a/src/component/app.jsx
+++ b/src/component/app.jsx
@@ -112,7 +112,7 @@ export default class App extends Component {
                 return [0, 0];
             }
         };
-        const createListItem = (path, caption, icon, isDrawerNavigation = false) => {
+        const createListItem = (path, caption, icon, isDrawerNavigation = false, isAnchor = false) => {
             const linkColor =
                 isDrawerNavigation && this.context.router.isActive(path)
                     ? 'mdl-color-text--black'
@@ -121,17 +121,26 @@ export default class App extends Component {
                 isDrawerNavigation && this.context.router.isActive(path)
                     ? 'mdl-color-text--black'
                     : 'mdl-color-text--grey-600';
-            return (
+            const renderIcon = (
+                <Icon
+                    name={icon}
+                    className={isDrawerNavigation ? [styles.navigationIcon, iconColor].join(' ') : undefined}
+                />
+            );
+            return isAnchor ? (
+                <a
+                    href={path}
+                    className={isDrawerNavigation ? [styles.navigationLink, linkColor].join(' ') : undefined}
+                >
+                    {icon && renderIcon}
+                    {caption}
+                </a>
+            ) : (
                 <Link
                     to={path}
                     className={isDrawerNavigation ? [styles.navigationLink, linkColor].join(' ') : undefined}
                 >
-                    {icon && (
-                        <Icon
-                            name={icon}
-                            className={isDrawerNavigation ? [styles.navigationIcon, iconColor].join(' ') : undefined}
-                        />
-                    )}
+                    {icon && renderIcon}
                     {caption}
                 </Link>
             );
@@ -158,6 +167,7 @@ export default class App extends Component {
                             {createListItem('/history', 'Event History', 'history', true)}
                             {createListItem('/archive', 'Archived Toggles', 'archive', true)}
                             {createListItem('/applications', 'Applications', 'apps', true)}
+                            {createListItem('/api/admin/user/logout', 'Sign out', 'exit_to_app', true, true)}
                         </Navigation>
                         <hr />
                         <Navigation className={styles.navigation}>


### PR DESCRIPTION
the `sign out` appears only in the footer menu which does not make it very visible. This is a proposal to display it:
![screenshot 2018-02-24 18 13 14_preview](https://user-images.githubusercontent.com/1395710/36633010-6b404ca8-198e-11e8-9564-365b9fb78985.png)
