### PR TITLE
fix: Prevent text highlighting overlap between chips

### DIFF
--- a/src/component/feature/form/__tests__/__snapshots__/strategy-input-list-test.jsx.snap
+++ b/src/component/feature/form/__tests__/__snapshots__/strategy-input-list-test.jsx.snap
@@ -5,24 +5,32 @@ exports[`renders correctly when disabled 1`] = `
   <p>
     featureName
   </p>
-  <react-mdl-Chip
+  <div
     style={
       Object {
-        "marginRight": "3px",
+        "display": "flex",
       }
     }
   >
-    item1
-  </react-mdl-Chip>
-  <react-mdl-Chip
-    style={
-      Object {
-        "marginRight": "3px",
+    <react-mdl-Chip
+      style={
+        Object {
+          "marginRight": "3px",
+        }
       }
-    }
-  >
-    item2
-  </react-mdl-Chip>
+    >
+      item1
+    </react-mdl-Chip>
+    <react-mdl-Chip
+      style={
+        Object {
+          "marginRight": "3px",
+        }
+      }
+    >
+      item2
+    </react-mdl-Chip>
+  </div>
   
 </div>
 `;
@@ -32,6 +40,13 @@ exports[`renders strategy with empty list as param 1`] = `
   <p>
     featureName
   </p>
+  <div
+    style={
+      Object {
+        "display": "flex",
+      }
+    }
+  />
   <div
     style={
       Object {
@@ -73,26 +88,34 @@ exports[`renders strategy with list as param 1`] = `
   <p>
     featureName
   </p>
-  <react-mdl-Chip
-    onClose={[Function]}
+  <div
     style={
       Object {
-        "marginRight": "3px",
+        "display": "flex",
       }
     }
   >
-    item1
-  </react-mdl-Chip>
-  <react-mdl-Chip
-    onClose={[Function]}
-    style={
-      Object {
-        "marginRight": "3px",
+    <react-mdl-Chip
+      onClose={[Function]}
+      style={
+        Object {
+          "marginRight": "3px",
+        }
       }
-    }
-  >
-    item2
-  </react-mdl-Chip>
+    >
+      item1
+    </react-mdl-Chip>
+    <react-mdl-Chip
+      onClose={[Function]}
+      style={
+        Object {
+          "marginRight": "3px",
+        }
+      }
+    >
+      item2
+    </react-mdl-Chip>
+  </div>
   <div
     style={
       Object {

--- a/src/component/feature/form/strategy-input-list.jsx
+++ b/src/component/feature/form/strategy-input-list.jsx
@@ -54,15 +54,18 @@ export default class InputList extends Component {
         return (
             <div>
                 <p>{name}</p>
-                {list.map((entryValue, index) => (
-                    <Chip
-                        key={index + entryValue}
-                        style={{ marginRight: '3px' }}
-                        onClose={disabled ? undefined : () => this.onClose(index)}
-                    >
-                        {entryValue}
-                    </Chip>
-                ))}
+
+                <div style={{ display: 'flex' }}>
+                    {list.map((entryValue, index) => (
+                        <Chip
+                            key={index + entryValue}
+                            style={{ marginRight: '3px' }}
+                            onClose={disabled ? undefined : () => this.onClose(index)}
+                        >
+                            {entryValue}
+                        </Chip>
+                    ))}
+                </div>
 
                 {disabled ? (
                     ''


### PR DESCRIPTION
**Issue**
When double-clicking on a chip, text belonging to a different chip also gets highlighted. After copying and pasting, any unwanted text then has to be removed manually.

**Affected browsers**
Only tested on Chrome 76

**Solution**
The proposed solution is to wrap chip span elements in a flex enabled div which will prevent multiple chip texts from getting highlighted after double-clicking. 

*Before*
<img width="152" alt="Screen Shot 2019-09-18 at 10 20 31 AM" src="https://user-images.githubusercontent.com/5665868/65130586-04fb2800-d9fe-11e9-8d83-e32b1e179753.png">
Text selected after double-clicking the chip text: `cancel456`
The "cancel" bit comes from the close button description located in the previous chip in the list.

*After*
<img width="152" alt="Screen Shot 2019-09-18 at 10 24 16 AM" src="https://user-images.githubusercontent.com/5665868/65130935-b00be180-d9fe-11e9-8c42-a03a9240a424.png">
Text selected after double-clicking the chip text: `456`
