### PR TITLE
allow hiding of feature toggle

### DIFF
--- a/src/component/feature/__tests__/__snapshots__/feature-list-item-component-test.jsx.snap
+++ b/src/component/feature/__tests__/__snapshots__/feature-list-item-component-test.jsx.snap
@@ -1,5 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`doesn't render a toggle when hideFeatureToggle is true 1`] = `
+<react-mdl-ListItem
+  twoLine={true}
+>
+  <span
+    className="listItemMetric"
+  >
+    <svg
+      className="mdl-color-text--grey-300"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M17.3,18C19,16.5 20,14.4 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12C4,14.4 5,16.5 6.7,18C8.2,16.7 10,16 12,16C14,16 15.9,16.7 17.3,18M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2M7,9A1,1 0 0,1 8,10A1,1 0 0,1 7,11A1,1 0 0,1 6,10A1,1 0 0,1 7,9M10,6A1,1 0 0,1 11,7A1,1 0 0,1 10,8A1,1 0 0,1 9,7A1,1 0 0,1 10,6M17,9A1,1 0 0,1 18,10A1,1 0 0,1 17,11A1,1 0 0,1 16,10A1,1 0 0,1 17,9M14.4,6.1C14.9,6.3 15.1,6.9 15,7.4L13.6,10.8C13.8,11.1 14,11.5 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12C10,11 10.7,10.1 11.7,10L13.1,6.7C13.3,6.1 13.9,5.9 14.4,6.1Z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
+  <span
+    data-test="hidden-toggle"
+  />
+  <span
+    className="mdl-list__item-primary-content listItemLink"
+  >
+    <a
+      className="listLink truncate"
+      href="/features/strategies/Another"
+      onClick={[Function]}
+    >
+      Another
+      <span
+        className="mdl-list__item-sub-title truncate"
+      >
+        another's description
+      </span>
+    </a>
+  </span>
+  <span
+    className="listItemStrategies hideLt920"
+  >
+    <react-mdl-Chip
+      className="strategyChip"
+    >
+      gradualRolloutRandom
+    </react-mdl-Chip>
+  </span>
+  <span />
+</react-mdl-ListItem>
+`;
+
 exports[`renders correctly with one feature 1`] = `
 <react-mdl-ListItem
   twoLine={true}

--- a/src/component/feature/__tests__/feature-list-item-component-test.jsx
+++ b/src/component/feature/__tests__/feature-list-item-component-test.jsx
@@ -34,6 +34,42 @@ test('renders correctly with one feature', () => {
                 feature={feature}
                 toggleFeature={jest.fn()}
                 hasPermission={permission => permission === UPDATE_FEATURE}
+                hideFeatureToggle={false}
+            />
+        </MemoryRouter>
+    );
+
+    expect(tree).toMatchSnapshot();
+});
+
+test("doesn't render a toggle when hideFeatureToggle is true", () => {
+    const feature = {
+        name: 'Another',
+        description: "another's description",
+        enabled: false,
+        strategies: [
+            {
+                name: 'gradualRolloutRandom',
+                parameters: {
+                    percentage: 50,
+                },
+            },
+        ],
+        createdAt: '2018-02-04T20:27:52.127Z',
+    };
+    const featureMetrics = { lastHour: {}, lastMinute: {}, seenApps: {} };
+    const settings = { sort: 'name' };
+    const tree = renderer.create(
+        <MemoryRouter>
+            <Feature
+                key={0}
+                settings={settings}
+                metricsLastHour={featureMetrics.lastHour[feature.name]}
+                metricsLastMinute={featureMetrics.lastMinute[feature.name]}
+                feature={feature}
+                toggleFeature={jest.fn()}
+                hasPermission={permission => permission === UPDATE_FEATURE}
+                hideFeatureToggle
             />
         </MemoryRouter>
     );
@@ -68,6 +104,7 @@ test('renders correctly with one feature without permission', () => {
                 feature={feature}
                 toggleFeature={jest.fn()}
                 hasPermission={() => false}
+                hideFeatureToggle={false}
             />
         </MemoryRouter>
     );

--- a/src/component/feature/feature-list-item-component.jsx
+++ b/src/component/feature/feature-list-item-component.jsx
@@ -16,6 +16,7 @@ const Feature = ({
     metricsLastMinute = { yes: 0, no: 0, isFallback: true },
     revive,
     hasPermission,
+    hideFeatureToggle = false,
 }) => {
     const { name, description, enabled, strategies } = feature;
     const { showLastHour = false } = settings;
@@ -42,19 +43,23 @@ const Feature = ({
             <span className={styles.listItemMetric}>
                 <Progress strokeWidth={15} percentage={percent} isFallback={isStale} />
             </span>
-            <span className={styles.listItemToggle}>
-                {hasPermission(UPDATE_FEATURE) ? (
-                    <Switch
-                        disabled={toggleFeature === undefined}
-                        title={`Toggle ${name}`}
-                        key="left-actions"
-                        onChange={() => toggleFeature(!enabled, name)}
-                        checked={enabled}
-                    />
-                ) : (
-                    <Switch disabled title={`Toggle ${name}`} key="left-actions" checked={enabled} />
-                )}
-            </span>
+            {hideFeatureToggle ? (
+                <span data-test="hidden-toggle" />
+            ) : (
+                <span className={styles.listItemToggle}>
+                    {hasPermission(UPDATE_FEATURE) ? (
+                        <Switch
+                            disabled={toggleFeature === undefined}
+                            title={`Toggle ${name}`}
+                            key="left-actions"
+                            onChange={() => toggleFeature(!enabled, name)}
+                            checked={enabled}
+                        />
+                    ) : (
+                        <Switch disabled title={`Toggle ${name}`} key="left-actions" checked={enabled} />
+                    )}
+                </span>
+            )}
             <span className={['mdl-list__item-primary-content', styles.listItemLink].join(' ')}>
                 <Link to={featureUrl} className={[commonStyles.listLink, commonStyles.truncate].join(' ')}>
                     {name}
@@ -84,6 +89,7 @@ Feature.propTypes = {
     metricsLastMinute: PropTypes.object,
     revive: PropTypes.func,
     hasPermission: PropTypes.func.isRequired,
+    hideFeatureToggle: PropTypes.bool,
 };
 
 export default Feature;

--- a/src/component/feature/list-component.jsx
+++ b/src/component/feature/list-component.jsx
@@ -19,6 +19,7 @@ export default class FeatureListComponent extends React.Component {
         settings: PropTypes.object,
         history: PropTypes.object.isRequired,
         hasPermission: PropTypes.func.isRequired,
+        hideFeatureToggle: PropTypes.bool.isRequired,
     };
 
     componentDidMount() {
@@ -42,7 +43,16 @@ export default class FeatureListComponent extends React.Component {
     }
 
     render() {
-        const { features, toggleFeature, featureMetrics, settings, revive, hasPermission } = this.props;
+        const {
+            features,
+            toggleFeature,
+            featureMetrics,
+            settings,
+            revive,
+            hasPermission,
+            hideFeatureToggle,
+        } = this.props;
+
         features.forEach(e => {
             e.reviveName = e.name;
         });
@@ -121,6 +131,7 @@ export default class FeatureListComponent extends React.Component {
                                     toggleFeature={toggleFeature}
                                     revive={revive}
                                     hasPermission={hasPermission}
+                                    hideFeatureToggle={hideFeatureToggle}
                                 />
                             ))
                         ) : (

--- a/src/component/feature/list-container.jsx
+++ b/src/component/feature/list-container.jsx
@@ -69,6 +69,7 @@ export const mapStateToPropsConfigurable = isFeature => state => {
         featureMetrics,
         settings,
         hasPermission: hasPermission.bind(null, state.user.get('profile')),
+        hideFeatureToggle: state.uiConfig.get('hideFeatureToggle'),
     };
 };
 const mapStateToProps = mapStateToPropsConfigurable(true);


### PR DESCRIPTION
Hello, 

Love unleash and looking forwards deploying it. However, I find myself activating and deactivating the toggles when trying to navigate to the feature. 

This PR gives the option to pass a flag in the config to hide it.


_Note: This is more of a proposal, the empty span isn't good but the UI library really didn't like being  given  null/undefined.
I'd also like to have written some more specific unit tests instead of relying on the snapshot however I kept running into a memory leak._