### PR TITLE
fix: metrics invalid date

### DIFF
--- a/src/component/feature/view/metric-component.jsx
+++ b/src/component/feature/view/metric-component.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { AppsLinkList, calc } from '../../common';
 import { formatFullDateTimeWithLocale } from '../../common/util';
 import styles from './metric.module.scss';
+import ConditionallyRender from '../../common/conditionally-render';
 
 const StrategyChipItem = ({ strategy }) => (
     <Chip className={styles.chip}>
@@ -116,8 +117,16 @@ export default class MetricComponent extends React.Component {
                         )}
                         <AppsLinkList apps={seenApps} />
                         <div>
-                            <strong>Created: </strong>
-                            <span>{this.formatFullDateTime(featureToggle.createdAt)}</span>
+                            <ConditionallyRender
+                                condition={featureToggle.createdAt}
+                                show={
+                                    <>
+                                        <strong>Created: </strong>
+                                        <span>{this.formatFullDateTime(featureToggle.createdAt)}</span>
+                                    </>
+                                }
+                            />
+
                             <br />
                             <strong>Last seen: </strong>
                             <span>{this.renderLastSeen(featureToggle.lastSeenAt)}</span>

--- a/src/store/feature-toggle/actions.js
+++ b/src/store/feature-toggle/actions.js
@@ -1,70 +1,69 @@
-import api from "./api";
-const debug = require("debug")("unleash:feature-actions");
-import { dispatchAndThrow } from "../util";
-import { MUTE_ERROR } from "../error/actions";
+import api from './api';
+const debug = require('debug')('unleash:feature-actions');
+import { dispatchAndThrow } from '../util';
+import { MUTE_ERROR } from '../error/actions';
 
-export const ADD_FEATURE_TOGGLE = "ADD_FEATURE_TOGGLE";
-export const COPY_FEATURE_TOGGLE = "COPY_FEATURE_TOGGLE";
-export const REMOVE_FEATURE_TOGGLE = "REMOVE_FEATURE_TOGGLE";
-export const UPDATE_FEATURE_TOGGLE = "UPDATE_FEATURE_TOGGLE";
-export const TOGGLE_FEATURE_TOGGLE = "TOGGLE_FEATURE_TOGGLE";
-export const START_FETCH_FEATURE_TOGGLES = "START_FETCH_FEATURE_TOGGLES";
-export const START_UPDATE_FEATURE_TOGGLE = "START_UPDATE_FEATURE_TOGGLE";
-export const START_CREATE_FEATURE_TOGGLE = "START_CREATE_FEATURE_TOGGLE";
-export const START_REMOVE_FEATURE_TOGGLE = "START_REMOVE_FEATURE_TOGGLE";
-export const RECEIVE_FEATURE_TOGGLES = "RECEIVE_FEATURE_TOGGLES";
-export const ERROR_FETCH_FEATURE_TOGGLES = "ERROR_FETCH_FEATURE_TOGGLES";
-export const ERROR_CREATING_FEATURE_TOGGLE = "ERROR_CREATING_FEATURE_TOGGLE";
-export const ERROR_UPDATE_FEATURE_TOGGLE = "ERROR_UPDATE_FEATURE_TOGGLE";
-export const ERROR_REMOVE_FEATURE_TOGGLE = "ERROR_REMOVE_FEATURE_TOGGLE";
-export const UPDATE_FEATURE_TOGGLE_STRATEGIES =
-    "UPDATE_FEATURE_TOGGLE_STRATEGIES";
+export const ADD_FEATURE_TOGGLE = 'ADD_FEATURE_TOGGLE';
+export const COPY_FEATURE_TOGGLE = 'COPY_FEATURE_TOGGLE';
+export const REMOVE_FEATURE_TOGGLE = 'REMOVE_FEATURE_TOGGLE';
+export const UPDATE_FEATURE_TOGGLE = 'UPDATE_FEATURE_TOGGLE';
+export const TOGGLE_FEATURE_TOGGLE = 'TOGGLE_FEATURE_TOGGLE';
+export const START_FETCH_FEATURE_TOGGLES = 'START_FETCH_FEATURE_TOGGLES';
+export const START_UPDATE_FEATURE_TOGGLE = 'START_UPDATE_FEATURE_TOGGLE';
+export const START_CREATE_FEATURE_TOGGLE = 'START_CREATE_FEATURE_TOGGLE';
+export const START_REMOVE_FEATURE_TOGGLE = 'START_REMOVE_FEATURE_TOGGLE';
+export const RECEIVE_FEATURE_TOGGLES = 'RECEIVE_FEATURE_TOGGLES';
+export const ERROR_FETCH_FEATURE_TOGGLES = 'ERROR_FETCH_FEATURE_TOGGLES';
+export const ERROR_CREATING_FEATURE_TOGGLE = 'ERROR_CREATING_FEATURE_TOGGLE';
+export const ERROR_UPDATE_FEATURE_TOGGLE = 'ERROR_UPDATE_FEATURE_TOGGLE';
+export const ERROR_REMOVE_FEATURE_TOGGLE = 'ERROR_REMOVE_FEATURE_TOGGLE';
+export const UPDATE_FEATURE_TOGGLE_STRATEGIES = 'UPDATE_FEATURE_TOGGLE_STRATEGIES';
 
-export const RECEIVE_FEATURE_TOGGLE = "RECEIVE_FEATURE_TOGGLE";
-export const START_FETCH_FEATURE_TOGGLE = "START_FETCH_FEATURE_TOGGLE";
-export const ERROR_FETCH_FEATURE_TOGGLE = "START_FETCH_FEATURE_TOGGLE";
+export const RECEIVE_FEATURE_TOGGLE = 'RECEIVE_FEATURE_TOGGLE';
+export const START_FETCH_FEATURE_TOGGLE = 'START_FETCH_FEATURE_TOGGLE';
+export const ERROR_FETCH_FEATURE_TOGGLE = 'START_FETCH_FEATURE_TOGGLE';
 
 export function toggleFeature(enable, name) {
-    debug("Toggle feature toggle ", name);
+    debug('Toggle feature toggle ', name);
     return dispatch => {
         dispatch(requestToggleFeatureToggle(enable, name));
     };
 }
 
 export function setStale(stale, name) {
-    debug("Set stale property on feature toggle ", name);
+    debug('Set stale property on feature toggle ', name);
     return dispatch => {
         dispatch(requestSetStaleFeatureToggle(stale, name));
     };
 }
 
 export function editFeatureToggle(featureToggle) {
-    debug("Update feature toggle ", featureToggle);
+    debug('Update feature toggle ', featureToggle);
     return dispatch => {
         dispatch(requestUpdateFeatureToggle(featureToggle));
     };
 }
 
 function receiveFeatureToggles(json) {
-    debug("reviced feature toggles", json);
+    debug('reviced feature toggles', json);
     return {
         type: RECEIVE_FEATURE_TOGGLES,
         featureToggles: json.features.map(features => features),
-        receivedAt: Date.now()
+        receivedAt: Date.now(),
     };
 }
 
 function receiveFeatureToggle(featureToggle) {
-    debug("reviced feature toggle", featureToggle);
+    debug('reviced feature toggle', featureToggle);
     return {
         type: RECEIVE_FEATURE_TOGGLE,
         featureToggle,
-        receivedAt: Date.now()
+        receivedAt: Date.now(),
     };
 }
 
 export function fetchFeatureToggles() {
-    debug("Start fetching feature toggles");
+    debug('Start fetching feature toggles');
     return dispatch => {
         dispatch({ type: START_FETCH_FEATURE_TOGGLES });
 
@@ -76,7 +75,7 @@ export function fetchFeatureToggles() {
 }
 
 export function fetchFeatureToggle(name) {
-    debug("Start fetching feature toggles");
+    debug('Start fetching feature toggles');
 
     return dispatch => {
         dispatch({ type: START_FETCH_FEATURE_TOGGLE });
@@ -120,11 +119,8 @@ export function requestSetStaleFeatureToggle(stale, name) {
         return api
             .setStale(stale, name)
             .then(featureToggle => {
-                const info = `${name} marked as ${stale ? "Stale" : "Active"}.`;
-                setTimeout(
-                    () => dispatch({ type: MUTE_ERROR, error: info }),
-                    1000
-                );
+                const info = `${name} marked as ${stale ? 'Stale' : 'Active'}.`;
+                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
                 dispatch({ type: UPDATE_FEATURE_TOGGLE, featureToggle, info });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
@@ -139,20 +135,14 @@ export function requestUpdateFeatureToggle(featureToggle) {
             .update(featureToggle)
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
-                setTimeout(
-                    () => dispatch({ type: MUTE_ERROR, error: info }),
-                    1000
-                );
+                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
                 dispatch({ type: UPDATE_FEATURE_TOGGLE, featureToggle, info });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
     };
 }
 
-export function requestUpdateFeatureToggleStrategies(
-    featureToggle,
-    newStrategies
-) {
+export function requestUpdateFeatureToggleStrategies(featureToggle, newStrategies) {
     return dispatch => {
         featureToggle.strategies = newStrategies;
         dispatch({ type: START_UPDATE_FEATURE_TOGGLE });
@@ -161,14 +151,11 @@ export function requestUpdateFeatureToggleStrategies(
             .update(featureToggle)
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
-                setTimeout(
-                    () => dispatch({ type: MUTE_ERROR, error: info }),
-                    1000
-                );
+                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
                 return dispatch({
                     type: UPDATE_FEATURE_TOGGLE_STRATEGIES,
                     featureToggle,
-                    info
+                    info,
                 });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
@@ -184,14 +171,11 @@ export function requestUpdateFeatureToggleVariants(featureToggle, newVariants) {
             .update(featureToggle)
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
-                setTimeout(
-                    () => dispatch({ type: MUTE_ERROR, error: info }),
-                    1000
-                );
+                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
                 return dispatch({
                     type: UPDATE_FEATURE_TOGGLE_STRATEGIES,
                     featureToggle,
-                    info
+                    info,
                 });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
@@ -204,9 +188,7 @@ export function removeFeatureToggle(featureToggleName) {
 
         return api
             .remove(featureToggleName)
-            .then(() =>
-                dispatch({ type: REMOVE_FEATURE_TOGGLE, featureToggleName })
-            )
+            .then(() => dispatch({ type: REMOVE_FEATURE_TOGGLE, featureToggleName }))
             .catch(dispatchAndThrow(dispatch, ERROR_REMOVE_FEATURE_TOGGLE));
     };
 }

--- a/src/store/feature-toggle/actions.js
+++ b/src/store/feature-toggle/actions.js
@@ -1,69 +1,70 @@
-import api from './api';
-const debug = require('debug')('unleash:feature-actions');
-import { dispatchAndThrow } from '../util';
-import { MUTE_ERROR } from '../error/actions';
+import api from "./api";
+const debug = require("debug")("unleash:feature-actions");
+import { dispatchAndThrow } from "../util";
+import { MUTE_ERROR } from "../error/actions";
 
-export const ADD_FEATURE_TOGGLE = 'ADD_FEATURE_TOGGLE';
-export const COPY_FEATURE_TOGGLE = 'COPY_FEATURE_TOGGLE';
-export const REMOVE_FEATURE_TOGGLE = 'REMOVE_FEATURE_TOGGLE';
-export const UPDATE_FEATURE_TOGGLE = 'UPDATE_FEATURE_TOGGLE';
-export const TOGGLE_FEATURE_TOGGLE = 'TOGGLE_FEATURE_TOGGLE';
-export const START_FETCH_FEATURE_TOGGLES = 'START_FETCH_FEATURE_TOGGLES';
-export const START_UPDATE_FEATURE_TOGGLE = 'START_UPDATE_FEATURE_TOGGLE';
-export const START_CREATE_FEATURE_TOGGLE = 'START_CREATE_FEATURE_TOGGLE';
-export const START_REMOVE_FEATURE_TOGGLE = 'START_REMOVE_FEATURE_TOGGLE';
-export const RECEIVE_FEATURE_TOGGLES = 'RECEIVE_FEATURE_TOGGLES';
-export const ERROR_FETCH_FEATURE_TOGGLES = 'ERROR_FETCH_FEATURE_TOGGLES';
-export const ERROR_CREATING_FEATURE_TOGGLE = 'ERROR_CREATING_FEATURE_TOGGLE';
-export const ERROR_UPDATE_FEATURE_TOGGLE = 'ERROR_UPDATE_FEATURE_TOGGLE';
-export const ERROR_REMOVE_FEATURE_TOGGLE = 'ERROR_REMOVE_FEATURE_TOGGLE';
-export const UPDATE_FEATURE_TOGGLE_STRATEGIES = 'UPDATE_FEATURE_TOGGLE_STRATEGIES';
+export const ADD_FEATURE_TOGGLE = "ADD_FEATURE_TOGGLE";
+export const COPY_FEATURE_TOGGLE = "COPY_FEATURE_TOGGLE";
+export const REMOVE_FEATURE_TOGGLE = "REMOVE_FEATURE_TOGGLE";
+export const UPDATE_FEATURE_TOGGLE = "UPDATE_FEATURE_TOGGLE";
+export const TOGGLE_FEATURE_TOGGLE = "TOGGLE_FEATURE_TOGGLE";
+export const START_FETCH_FEATURE_TOGGLES = "START_FETCH_FEATURE_TOGGLES";
+export const START_UPDATE_FEATURE_TOGGLE = "START_UPDATE_FEATURE_TOGGLE";
+export const START_CREATE_FEATURE_TOGGLE = "START_CREATE_FEATURE_TOGGLE";
+export const START_REMOVE_FEATURE_TOGGLE = "START_REMOVE_FEATURE_TOGGLE";
+export const RECEIVE_FEATURE_TOGGLES = "RECEIVE_FEATURE_TOGGLES";
+export const ERROR_FETCH_FEATURE_TOGGLES = "ERROR_FETCH_FEATURE_TOGGLES";
+export const ERROR_CREATING_FEATURE_TOGGLE = "ERROR_CREATING_FEATURE_TOGGLE";
+export const ERROR_UPDATE_FEATURE_TOGGLE = "ERROR_UPDATE_FEATURE_TOGGLE";
+export const ERROR_REMOVE_FEATURE_TOGGLE = "ERROR_REMOVE_FEATURE_TOGGLE";
+export const UPDATE_FEATURE_TOGGLE_STRATEGIES =
+    "UPDATE_FEATURE_TOGGLE_STRATEGIES";
 
-export const RECEIVE_FEATURE_TOGGLE = 'RECEIVE_FEATURE_TOGGLE';
-export const START_FETCH_FEATURE_TOGGLE = 'START_FETCH_FEATURE_TOGGLE';
-export const ERROR_FETCH_FEATURE_TOGGLE = 'START_FETCH_FEATURE_TOGGLE';
+export const RECEIVE_FEATURE_TOGGLE = "RECEIVE_FEATURE_TOGGLE";
+export const START_FETCH_FEATURE_TOGGLE = "START_FETCH_FEATURE_TOGGLE";
+export const ERROR_FETCH_FEATURE_TOGGLE = "START_FETCH_FEATURE_TOGGLE";
 
 export function toggleFeature(enable, name) {
-    debug('Toggle feature toggle ', name);
+    debug("Toggle feature toggle ", name);
     return dispatch => {
         dispatch(requestToggleFeatureToggle(enable, name));
     };
 }
 
 export function setStale(stale, name) {
-    debug('Set stale property on feature toggle ', name);
+    debug("Set stale property on feature toggle ", name);
     return dispatch => {
         dispatch(requestSetStaleFeatureToggle(stale, name));
     };
 }
 
 export function editFeatureToggle(featureToggle) {
-    debug('Update feature toggle ', featureToggle);
+    debug("Update feature toggle ", featureToggle);
     return dispatch => {
         dispatch(requestUpdateFeatureToggle(featureToggle));
     };
 }
 
 function receiveFeatureToggles(json) {
-    debug('reviced feature toggles', json);
+    debug("reviced feature toggles", json);
     return {
         type: RECEIVE_FEATURE_TOGGLES,
         featureToggles: json.features.map(features => features),
-        receivedAt: Date.now(),
+        receivedAt: Date.now()
     };
 }
 
 function receiveFeatureToggle(featureToggle) {
-    debug('reviced feature toggle', featureToggle);
+    debug("reviced feature toggle", featureToggle);
     return {
         type: RECEIVE_FEATURE_TOGGLE,
         featureToggle,
-        receivedAt: Date.now(),
+        receivedAt: Date.now()
     };
 }
 
 export function fetchFeatureToggles() {
-    debug('Start fetching feature toggles');
+    debug("Start fetching feature toggles");
     return dispatch => {
         dispatch({ type: START_FETCH_FEATURE_TOGGLES });
 
@@ -75,7 +76,7 @@ export function fetchFeatureToggles() {
 }
 
 export function fetchFeatureToggle(name) {
-    debug('Start fetching feature toggles');
+    debug("Start fetching feature toggles");
 
     return dispatch => {
         dispatch({ type: START_FETCH_FEATURE_TOGGLE });
@@ -93,8 +94,10 @@ export function createFeatureToggles(featureToggle) {
 
         return api
             .create(featureToggle)
-            .then(() => dispatch({ type: ADD_FEATURE_TOGGLE, featureToggle }))
-            .then(() => fetchFeatureToggle(featureToggle.name)(dispatch))
+            .then(res => res.json())
+            .then(featureToggle => {
+                dispatch({ type: ADD_FEATURE_TOGGLE, featureToggle });
+            })
             .catch(dispatchAndThrow(dispatch, ERROR_CREATING_FEATURE_TOGGLE));
     };
 }
@@ -117,8 +120,11 @@ export function requestSetStaleFeatureToggle(stale, name) {
         return api
             .setStale(stale, name)
             .then(featureToggle => {
-                const info = `${name} marked as ${stale ? 'Stale' : 'Active'}.`;
-                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
+                const info = `${name} marked as ${stale ? "Stale" : "Active"}.`;
+                setTimeout(
+                    () => dispatch({ type: MUTE_ERROR, error: info }),
+                    1000
+                );
                 dispatch({ type: UPDATE_FEATURE_TOGGLE, featureToggle, info });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
@@ -133,14 +139,20 @@ export function requestUpdateFeatureToggle(featureToggle) {
             .update(featureToggle)
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
-                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
+                setTimeout(
+                    () => dispatch({ type: MUTE_ERROR, error: info }),
+                    1000
+                );
                 dispatch({ type: UPDATE_FEATURE_TOGGLE, featureToggle, info });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
     };
 }
 
-export function requestUpdateFeatureToggleStrategies(featureToggle, newStrategies) {
+export function requestUpdateFeatureToggleStrategies(
+    featureToggle,
+    newStrategies
+) {
     return dispatch => {
         featureToggle.strategies = newStrategies;
         dispatch({ type: START_UPDATE_FEATURE_TOGGLE });
@@ -149,11 +161,14 @@ export function requestUpdateFeatureToggleStrategies(featureToggle, newStrategie
             .update(featureToggle)
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
-                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
+                setTimeout(
+                    () => dispatch({ type: MUTE_ERROR, error: info }),
+                    1000
+                );
                 return dispatch({
                     type: UPDATE_FEATURE_TOGGLE_STRATEGIES,
                     featureToggle,
-                    info,
+                    info
                 });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
@@ -169,11 +184,14 @@ export function requestUpdateFeatureToggleVariants(featureToggle, newVariants) {
             .update(featureToggle)
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
-                setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
+                setTimeout(
+                    () => dispatch({ type: MUTE_ERROR, error: info }),
+                    1000
+                );
                 return dispatch({
                     type: UPDATE_FEATURE_TOGGLE_STRATEGIES,
                     featureToggle,
-                    info,
+                    info
                 });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
@@ -186,7 +204,9 @@ export function removeFeatureToggle(featureToggleName) {
 
         return api
             .remove(featureToggleName)
-            .then(() => dispatch({ type: REMOVE_FEATURE_TOGGLE, featureToggleName }))
+            .then(() =>
+                dispatch({ type: REMOVE_FEATURE_TOGGLE, featureToggleName })
+            )
             .catch(dispatchAndThrow(dispatch, ERROR_REMOVE_FEATURE_TOGGLE));
     };
 }

--- a/src/store/feature-toggle/actions.js
+++ b/src/store/feature-toggle/actions.js
@@ -94,8 +94,11 @@ export function createFeatureToggles(featureToggle) {
         return api
             .create(featureToggle)
             .then(res => res.json())
-            .then(featureToggle => {
-                dispatch({ type: ADD_FEATURE_TOGGLE, featureToggle });
+            .then(createdFeature => {
+                dispatch({
+                    type: ADD_FEATURE_TOGGLE,
+                    featureToggle: createdFeature,
+                });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_CREATING_FEATURE_TOGGLE));
     };

--- a/src/store/feature-toggle/actions.js
+++ b/src/store/feature-toggle/actions.js
@@ -76,6 +76,7 @@ export function fetchFeatureToggles() {
 
 export function fetchFeatureToggle(name) {
     debug('Start fetching feature toggles');
+
     return dispatch => {
         dispatch({ type: START_FETCH_FEATURE_TOGGLE });
 
@@ -93,6 +94,7 @@ export function createFeatureToggles(featureToggle) {
         return api
             .create(featureToggle)
             .then(() => dispatch({ type: ADD_FEATURE_TOGGLE, featureToggle }))
+            .then(() => fetchFeatureToggle(featureToggle.name)(dispatch))
             .catch(dispatchAndThrow(dispatch, ERROR_CREATING_FEATURE_TOGGLE));
     };
 }
@@ -148,7 +150,11 @@ export function requestUpdateFeatureToggleStrategies(featureToggle, newStrategie
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
                 setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
-                return dispatch({ type: UPDATE_FEATURE_TOGGLE_STRATEGIES, featureToggle, info });
+                return dispatch({
+                    type: UPDATE_FEATURE_TOGGLE_STRATEGIES,
+                    featureToggle,
+                    info,
+                });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
     };
@@ -164,7 +170,11 @@ export function requestUpdateFeatureToggleVariants(featureToggle, newVariants) {
             .then(() => {
                 const info = `${featureToggle.name} successfully updated!`;
                 setTimeout(() => dispatch({ type: MUTE_ERROR, error: info }), 1000);
-                return dispatch({ type: UPDATE_FEATURE_TOGGLE_STRATEGIES, featureToggle, info });
+                return dispatch({
+                    type: UPDATE_FEATURE_TOGGLE_STRATEGIES,
+                    featureToggle,
+                    info,
+                });
             })
             .catch(dispatchAndThrow(dispatch, ERROR_UPDATE_FEATURE_TOGGLE));
     };

--- a/src/store/feature-toggle/api.js
+++ b/src/store/feature-toggle/api.js
@@ -1,11 +1,14 @@
-import { throwIfNotSuccess, headers } from '../api-helper';
+import { throwIfNotSuccess, headers } from "../api-helper";
 
-const URI = 'api/admin/features';
+const URI = "api/admin/features";
 
 function validateToggle(featureToggle) {
     return new Promise((resolve, reject) => {
-        if (!featureToggle.strategies || featureToggle.strategies.length === 0) {
-            reject(new Error('You must add at least one activation strategy'));
+        if (
+            !featureToggle.strategies ||
+            featureToggle.strategies.length === 0
+        ) {
+            reject(new Error("You must add at least one activation strategy"));
         } else {
             resolve(featureToggle);
         }
@@ -13,36 +16,34 @@ function validateToggle(featureToggle) {
 }
 
 function fetchAll() {
-    return fetch(URI, { credentials: 'include' })
+    return fetch(URI, { credentials: "include" })
         .then(throwIfNotSuccess)
         .then(response => response.json());
 }
 
 function fetchFeatureToggle(name) {
-    return fetch(`${URI}/${name}`, { credentials: 'include' })
+    return fetch(`${URI}/${name}`, { credentials: "include" })
         .then(throwIfNotSuccess)
         .then(response => response.json());
 }
 
-function create(featureToggle) {
-    return validateToggle(featureToggle)
-        .then(() =>
-            fetch(URI, {
-                method: 'POST',
-                headers,
-                credentials: 'include',
-                body: JSON.stringify(featureToggle),
-            })
-        )
-        .then(throwIfNotSuccess);
+async function create(featureToggle) {
+    await validateToggle(featureToggle);
+
+    return fetch(URI, {
+        method: "POST",
+        headers,
+        credentials: "include",
+        body: JSON.stringify(featureToggle)
+    }).then(throwIfNotSuccess);
 }
 
 function validate(featureToggle) {
     return fetch(`${URI}/validate`, {
-        method: 'POST',
+        method: "POST",
         headers,
-        credentials: 'include',
-        body: JSON.stringify(featureToggle),
+        credentials: "include",
+        body: JSON.stringify(featureToggle)
     }).then(throwIfNotSuccess);
 }
 
@@ -50,30 +51,30 @@ function update(featureToggle) {
     return validateToggle(featureToggle)
         .then(() =>
             fetch(`${URI}/${featureToggle.name}`, {
-                method: 'PUT',
+                method: "PUT",
                 headers,
-                credentials: 'include',
-                body: JSON.stringify(featureToggle),
+                credentials: "include",
+                body: JSON.stringify(featureToggle)
             })
         )
         .then(throwIfNotSuccess);
 }
 
 function toggle(enable, name) {
-    const action = enable ? 'on' : 'off';
+    const action = enable ? "on" : "off";
     return fetch(`${URI}/${name}/toggle/${action}`, {
-        method: 'POST',
+        method: "POST",
         headers,
-        credentials: 'include',
+        credentials: "include"
     }).then(throwIfNotSuccess);
 }
 
 function setStale(isStale, name) {
-    const action = isStale ? 'on' : 'off';
+    const action = isStale ? "on" : "off";
     return fetch(`${URI}/${name}/stale/${action}`, {
-        method: 'POST',
+        method: "POST",
         headers,
-        credentials: 'include',
+        credentials: "include"
     })
         .then(throwIfNotSuccess)
         .then(response => response.json());
@@ -81,8 +82,8 @@ function setStale(isStale, name) {
 
 function remove(featureToggleName) {
     return fetch(`${URI}/${featureToggleName}`, {
-        method: 'DELETE',
-        credentials: 'include',
+        method: "DELETE",
+        credentials: "include"
     }).then(throwIfNotSuccess);
 }
 
@@ -94,5 +95,5 @@ export default {
     update,
     toggle,
     setStale,
-    remove,
+    remove
 };

--- a/src/store/feature-toggle/api.js
+++ b/src/store/feature-toggle/api.js
@@ -1,14 +1,11 @@
-import { throwIfNotSuccess, headers } from "../api-helper";
+import { throwIfNotSuccess, headers } from '../api-helper';
 
-const URI = "api/admin/features";
+const URI = 'api/admin/features';
 
 function validateToggle(featureToggle) {
     return new Promise((resolve, reject) => {
-        if (
-            !featureToggle.strategies ||
-            featureToggle.strategies.length === 0
-        ) {
-            reject(new Error("You must add at least one activation strategy"));
+        if (!featureToggle.strategies || featureToggle.strategies.length === 0) {
+            reject(new Error('You must add at least one activation strategy'));
         } else {
             resolve(featureToggle);
         }
@@ -16,13 +13,13 @@ function validateToggle(featureToggle) {
 }
 
 function fetchAll() {
-    return fetch(URI, { credentials: "include" })
+    return fetch(URI, { credentials: 'include' })
         .then(throwIfNotSuccess)
         .then(response => response.json());
 }
 
 function fetchFeatureToggle(name) {
-    return fetch(`${URI}/${name}`, { credentials: "include" })
+    return fetch(`${URI}/${name}`, { credentials: 'include' })
         .then(throwIfNotSuccess)
         .then(response => response.json());
 }
@@ -31,19 +28,19 @@ async function create(featureToggle) {
     await validateToggle(featureToggle);
 
     return fetch(URI, {
-        method: "POST",
+        method: 'POST',
         headers,
-        credentials: "include",
-        body: JSON.stringify(featureToggle)
+        credentials: 'include',
+        body: JSON.stringify(featureToggle),
     }).then(throwIfNotSuccess);
 }
 
 function validate(featureToggle) {
     return fetch(`${URI}/validate`, {
-        method: "POST",
+        method: 'POST',
         headers,
-        credentials: "include",
-        body: JSON.stringify(featureToggle)
+        credentials: 'include',
+        body: JSON.stringify(featureToggle),
     }).then(throwIfNotSuccess);
 }
 
@@ -51,30 +48,30 @@ function update(featureToggle) {
     return validateToggle(featureToggle)
         .then(() =>
             fetch(`${URI}/${featureToggle.name}`, {
-                method: "PUT",
+                method: 'PUT',
                 headers,
-                credentials: "include",
-                body: JSON.stringify(featureToggle)
+                credentials: 'include',
+                body: JSON.stringify(featureToggle),
             })
         )
         .then(throwIfNotSuccess);
 }
 
 function toggle(enable, name) {
-    const action = enable ? "on" : "off";
+    const action = enable ? 'on' : 'off';
     return fetch(`${URI}/${name}/toggle/${action}`, {
-        method: "POST",
+        method: 'POST',
         headers,
-        credentials: "include"
+        credentials: 'include',
     }).then(throwIfNotSuccess);
 }
 
 function setStale(isStale, name) {
-    const action = isStale ? "on" : "off";
+    const action = isStale ? 'on' : 'off';
     return fetch(`${URI}/${name}/stale/${action}`, {
-        method: "POST",
+        method: 'POST',
         headers,
-        credentials: "include"
+        credentials: 'include',
     })
         .then(throwIfNotSuccess)
         .then(response => response.json());
@@ -82,8 +79,8 @@ function setStale(isStale, name) {
 
 function remove(featureToggleName) {
     return fetch(`${URI}/${featureToggleName}`, {
-        method: "DELETE",
-        credentials: "include"
+        method: 'DELETE',
+        credentials: 'include',
     }).then(throwIfNotSuccess);
 }
 
@@ -95,5 +92,5 @@ export default {
     update,
     toggle,
     setStale,
-    remove
+    remove,
 };


### PR DESCRIPTION
Fixes an issue where createdAt field in the Metrics component showed: "Invalid date". The following steps have been done to prevent that from happening: 

- Added capabilities in unleash server to return the feature on create
- Added capabilities in unleash-frontend to receive the created feature and insert it into redux store.