### PR TITLE
chore: fix releases URL in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 The latest version of this document is always available in
-[releases][releases-url].
+[releases](https://github.com/Unleash/unleash-frontend/releases).
 
 # 4.0.0-alpha.14
 - fix: all global event log requires admin


### PR DESCRIPTION
The link is broken as the reference `releases-url` doesn't exist, so I replaced it with what I think it's supposed to be.