### PR TITLE
Fix/customer journey patches

### DIFF
--- a/src/assets/icons/logo-white-bg.svg
+++ b/src/assets/icons/logo-white-bg.svg
@@ -1,0 +1,7 @@
+<svg width="334" height="334" viewBox="0 0 334 334" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="167" cy="167" r="167" fill="white"/>
+<rect x="96.3462" y="96.3457" width="44.9615" height="141.308" fill="#1A4049"/>
+<rect x="192.692" y="96.3457" width="44.9615" height="141.308" fill="#1A4049"/>
+<path d="M237.654 192.693L237.654 237.655L96.3461 237.655L96.3461 192.693L237.654 192.693Z" fill="#1A4049"/>
+<rect x="192.692" y="192.693" width="44.9615" height="44.9615" fill="#817AFE"/>
+</svg>

--- a/src/component/common/Proclamation/Proclamation.tsx
+++ b/src/component/common/Proclamation/Proclamation.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Alert } from '@material-ui/lab';
 import ConditionallyRender from '../ConditionallyRender';
 import { Typography } from '@material-ui/core';
@@ -23,12 +23,17 @@ const renderProclamation = (id: string) => {
             return false;
         }
     }
+    console.log('RETURNING TRUE');
     return true;
 };
 
 const Proclamation = ({ toast }: IProclamationProps) => {
-    const [show, setShow] = useState(renderProclamation(toast?.id || ''));
+    const [show, setShow] = useState(false);
     const styles = useStyles();
+
+    useEffect(() => {
+        setShow(renderProclamation(toast?.id || ''));
+    }, [toast?.id]);
 
     const onClose = () => {
         if (localStorage) {

--- a/src/component/feature/strategy/AddStrategy/AddStrategy.styles.js
+++ b/src/component/feature/strategy/AddStrategy/AddStrategy.styles.js
@@ -11,6 +11,7 @@ export const useStyles = makeStyles(theme => ({
     },
     subTitle: {
         fontWeight: theme.fontWeight.semi,
-        margin: '1rem 0',
+        fontSize: theme.fontSizes.subHeader,
+        margin: '2rem 0 0.5rem 0',
     },
 }));

--- a/src/component/user/ForgottenPassword/ForgottenPassword.tsx
+++ b/src/component/user/ForgottenPassword/ForgottenPassword.tsx
@@ -50,7 +50,10 @@ const ForgottenPassword = () => {
             >
                 <Typography
                     variant="h2"
-                    className={commonStyles.title}
+                    className={classnames(
+                        commonStyles.title,
+                        commonStyles.textCenter
+                    )}
                     data-loading
                 >
                     Forgotten password
@@ -79,7 +82,11 @@ const ForgottenPassword = () => {
                         styles.container
                     )}
                 >
-                    <Typography variant="body1" data-loading>
+                    <Typography
+                        variant="body1"
+                        data-loading
+                        className={commonStyles.textCenter}
+                    >
                         Please provide your email address. If it exists in the
                         system we'll send a new reset link.
                     </Typography>

--- a/src/component/user/Login/Login.styles.js
+++ b/src/component/user/Login/Login.styles.js
@@ -33,8 +33,7 @@ export const useStyles = makeStyles(theme => ({
     title: {
         fontSize: theme.fontSizes.mainHeader,
         marginBottom: '1rem',
-        display: 'flex',
-        alignItems: 'center',
+        textAlign: 'center',
     },
     logo: {
         marginRight: '10px',

--- a/src/component/user/NewUser/NewUser.styles.ts
+++ b/src/component/user/NewUser/NewUser.styles.ts
@@ -10,8 +10,7 @@ export const useStyles = makeStyles(theme => ({
     title: {
         fontSize: theme.fontSizes.mainHeader,
         marginBottom: '1.25rem',
-        display: 'flex',
-        alignItems: 'center',
+        textAlign: 'center',
     },
     inviteText: {
         marginBottom: '1rem',

--- a/src/component/user/StandaloneBanner/StandaloneBanner.styles.ts
+++ b/src/component/user/StandaloneBanner/StandaloneBanner.styles.ts
@@ -38,9 +38,9 @@ export const useStyles = makeStyles(theme => ({
         fontSize: '2rem',
         fontWeight: '300',
     },
-    switchesContainer: {
+    logoContainer: {
         position: 'absolute',
-        bottom: '15px',
+        bottom: '-50px',
         left: '-50px',
         display: 'flex',
         flexDirection: 'column',
@@ -48,7 +48,8 @@ export const useStyles = makeStyles(theme => ({
             display: 'none',
         },
     },
-    switchIcon: {
-        height: '100px',
+    logo: {
+        width: '240px',
+        height: '240px',
     },
 }));

--- a/src/component/user/StandaloneBanner/StandaloneBanner.tsx
+++ b/src/component/user/StandaloneBanner/StandaloneBanner.tsx
@@ -2,8 +2,8 @@ import { FC } from 'react';
 
 import { Typography, useTheme } from '@material-ui/core';
 import Gradient from '../../common/Gradient/Gradient';
-import { ReactComponent as RightToggleIcon } from '../../../assets/icons/toggleRight.svg';
-import { ReactComponent as LeftToggleIcon } from '../../../assets/icons/toggleLeft.svg';
+
+import { ReactComponent as Logo } from '../../../assets/icons/logo-white-bg.svg';
 
 import { useStyles } from './StandaloneBanner.styles';
 
@@ -21,7 +21,6 @@ const StandaloneBanner: FC<IStandaloneBannerProps> = ({ title, children }) => {
             style={{
                 borderBottomLeftRadius: '3px',
                 borderTopLeftRadius: '3px',
-                overflow: 'hidden',
             }}
         >
             <div className={styles.container}>
@@ -33,10 +32,8 @@ const StandaloneBanner: FC<IStandaloneBannerProps> = ({ title, children }) => {
                 </Typography>
             </div>
 
-            <div className={styles.switchesContainer}>
-                <RightToggleIcon className={styles.switchIcon} />
-                <br></br>
-                <LeftToggleIcon className={styles.switchIcon} />
+            <div className={styles.logoContainer}>
+                <Logo className={styles.logo} />
             </div>
         </Gradient>
     );

--- a/src/component/user/common/StandaloneLayout/StandaloneLayout.styles.ts
+++ b/src/component/user/common/StandaloneLayout/StandaloneLayout.styles.ts
@@ -2,8 +2,8 @@ import { makeStyles } from '@material-ui/core/styles';
 
 export const useStyles = makeStyles(theme => ({
     container: {
-        padding: '4rem',
-        background: '#3a5663',
+        padding: '5.5rem',
+        background: '#EFF2F2',
         display: 'flex',
         [theme.breakpoints.down('sm')]: {
             flexDirection: 'column',

--- a/src/page/admin/users/AddUser/AddUserForm/AddUserForm.jsx
+++ b/src/page/admin/users/AddUser/AddUserForm/AddUserForm.jsx
@@ -55,6 +55,15 @@ function AddUserForm({
         });
     };
 
+    const sortRoles = (a, b) => {
+        if (b.name[0] < a.name[0]) {
+            return 1;
+        } else if (a.name[0] < b.name[0]) {
+            return -1;
+        }
+        return 0;
+    };
+
     const apiError =
         userApiErrors[ADD_USER_ERROR] || userApiErrors[UPDATE_USER_ERROR];
     return (
@@ -134,7 +143,7 @@ function AddUserForm({
                             onChange={updateNumberField}
                             data-loading
                         >
-                            {roles.map(role => (
+                            {roles.sort(sortRoles).map(role => (
                                 <FormControlLabel
                                     key={`role-${role.id}`}
                                     labelPlacement="end"


### PR DESCRIPTION
Makes improvements to standalone screens by adding the unleash logo, increasing the padding and changing the background color. In addition: 
- Handle a bug where toast is not displayed on first render
- Add more spacing between headers on Add Strategy modal
- Sort roles so Admin, Editor and Viewer is the order they are viewed in the list when adding new user.

<img width="1429" alt="Skjermbilde 2021-06-03 kl  15 57 38" src="https://user-images.githubusercontent.com/16081982/120657050-6e49f580-c484-11eb-830a-6bdeea4a5b8c.png">
