### PR TITLE
fix: improve passwordchecker

### DIFF
--- a/src/component/user/common/ResetPasswordForm/PasswordChecker/PasswordChecker.styles.ts
+++ b/src/component/user/common/ResetPasswordForm/PasswordChecker/PasswordChecker.styles.ts
@@ -4,7 +4,7 @@ export const useStyles = makeStyles(theme => ({
     container: {
         border: '1px solid #f1f1f1',
         borderRadius: '3px',
-        right: '100px',
+        position: 'relative',
         maxWidth: '350px',
         color: '#44606e',
     },
@@ -40,5 +40,10 @@ export const useStyles = makeStyles(theme => ({
     },
     helpIcon: {
         height: '17.5px',
+    },
+    repeatingError: {
+        marginTop: '0.5rem',
+        bottom: '0',
+        position: 'absolute',
     },
 }));

--- a/src/component/user/common/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/src/component/user/common/ResetPasswordForm/ResetPasswordForm.tsx
@@ -41,6 +41,10 @@ const ResetPasswordForm = ({ token, setLoading }: IResetPasswordProps) => {
     ]);
 
     useEffect(() => {
+        if (!password) {
+            setValidOwaspPassword(false);
+        }
+
         if (password === confirmPassword) {
             setMatchingPasswords(true);
         } else {


### PR DESCRIPTION
Handles an obscure case in the password checker where password is not accepted because of three repeating characters. Now the user will receive a warning that three characters in a row is not permitted.

<img width="392" alt="Skjermbilde 2021-06-03 kl  15 59 16" src="https://user-images.githubusercontent.com/16081982/120657305-a94c2900-c484-11eb-9437-54ffe8e236ec.png">