### PR TITLE
fix: loadNameFromHash pull name search param

### DIFF
--- a/src/component/common/util.js
+++ b/src/component/common/util.js
@@ -85,14 +85,9 @@ export function updateWeight(variants, totalWeight) {
     });
 }
 
-export function loadNameFromHash() {
-    let field = '';
-    try {
-        [, field] = document.location.hash.match(/name=([a-z0-9-_.]+)/i);
-    } catch (e) {
-        // nothing
-    }
-    return field;
+export function loadNameFromUrl() {
+    const params = new URLSearchParams(document.location.search);
+    return params.get('name') || '';
 }
 
 export const modalStyles = {

--- a/src/component/feature/create/CreateFeature/index.jsx
+++ b/src/component/feature/create/CreateFeature/index.jsx
@@ -6,7 +6,7 @@ import {
     validateName,
 } from '../../../../store/feature-toggle/actions';
 import CreateFeature from './CreateFeature';
-import { loadNameFromHash, showPnpsFeedback } from '../../../common/util';
+import { loadNameFromUrl, showPnpsFeedback } from '../../../common/util';
 import { showFeedback } from '../../../../store/feedback/actions';
 
 const defaultStrategy = {
@@ -27,7 +27,7 @@ function resolveCurrentProjectId(settings) {
 class WrapperComponent extends Component {
     constructor(props) {
         super();
-        const name = loadNameFromHash();
+        const name = loadNameFromUrl();
         this.state = {
             featureToggle: {
                 name,

--- a/src/component/strategies/CreateStrategy/index.js
+++ b/src/component/strategies/CreateStrategy/index.js
@@ -9,7 +9,7 @@ import {
 } from '../../../store/strategy/actions';
 
 import CreateStrategy from './CreateStrategy';
-import { loadNameFromHash } from '../../common/util';
+import { loadNameFromUrl } from '../../common/util';
 
 const STRATEGY_EXIST_ERROR = 'Error: Strategy with name';
 
@@ -141,7 +141,7 @@ const mapStateToProps = (state, props) => {
     return {
         strategy: strategy
             ? strategy
-            : { name: loadNameFromHash(), description: '', parameters: [] },
+            : { name: loadNameFromUrl(), description: '', parameters: [] },
         editMode,
     };
 };


### PR DESCRIPTION
* The current code is looking for the name in the hash, but the name is
  not passed in the hash, but the search (queryString) parameter.
* Uses the [URLSearchParams](http://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
  browser API to find the name
* Maybe this function should be renamed to `loadNameFromSearch`?

Fixes https://github.com/Unleash/unleash/issues/886