### PR TITLE
Mutate cache key for project when archiving feature.

### DIFF
--- a/src/component/feature/FeatureView2/FeatureView2.tsx
+++ b/src/component/feature/FeatureView2/FeatureView2.tsx
@@ -1,9 +1,10 @@
-import { Tabs, Tab } from '@material-ui/core';
+import { Tab, Tabs } from '@material-ui/core';
 import { useState } from 'react';
 import { Archive, FileCopy } from '@material-ui/icons';
-import { Route, useHistory, useParams, Link } from 'react-router-dom';
+import { Link, Route, useHistory, useParams } from 'react-router-dom';
 import useFeatureApi from '../../../hooks/api/actions/useFeatureApi/useFeatureApi';
 import useFeature from '../../../hooks/api/getters/useFeature/useFeature';
+import useProject from '../../../hooks/api/getters/useProject/useProject';
 import useTabs from '../../../hooks/useTabs';
 import useToast from '../../../hooks/useToast';
 import { IFeatureViewParams } from '../../../interfaces/params';
@@ -20,12 +21,11 @@ import FeatureSettings from './FeatureSettings/FeatureSettings';
 import useLoading from '../../../hooks/useLoading';
 import ConditionallyRender from '../../common/ConditionallyRender';
 import { getCreateTogglePath } from '../../../utils/route-path-helpers';
-import { useSWRConfig } from 'swr';
 
 const FeatureView2 = () => {
     const { projectId, featureId } = useParams<IFeatureViewParams>();
     const { feature, loading, error } = useFeature(projectId, featureId);
-    const { mutate } = useSWRConfig();
+    const { refetch: projectRefetch } = useProject(projectId);
     const { a11yProps } = useTabs(0);
     const { archiveFeatureToggle } = useFeatureApi();
     const { toast, setToastData } = useToast();
@@ -45,7 +45,7 @@ const FeatureView2 = () => {
                 show: true,
             });
             setShowDelDialog(false);
-            mutate(`/api/admin/projects/${projectId}`);
+            projectRefetch();
             history.push(`/projects/${projectId}`);
         } catch (e) {
             setToastData({


### PR DESCRIPTION
- This causes a refetch of the feature list for project, preventing the
  just archived feature being present in the feature list when
  redirected back to the project feature list.