### PR TITLE
fix: Adds PermissionSwitch

### DIFF
--- a/src/component/common/PermissionSwitch/PermissionSwitch.tsx
+++ b/src/component/common/PermissionSwitch/PermissionSwitch.tsx
@@ -1,0 +1,40 @@
+import { Switch, Tooltip } from '@material-ui/core';
+import { OverridableComponent } from '@material-ui/core/OverridableComponent';
+import AccessContext from '../../../contexts/AccessContext';
+import React, { useContext } from 'react';
+
+interface IPermissionSwitchProps extends OverridableComponent<any> {
+    permission: string;
+    tooltip: string;
+    onChange?: (e: any) => void;
+    disabled?: boolean;
+    projectId?: string;
+}
+
+const PermissionSwitch: React.FC<IPermissionSwitchProps> = ({
+    permission,
+    tooltip = '',
+    disabled,
+    projectId,
+    onChange,
+    ...rest
+}) => {
+    const { hasAccess } = useContext(AccessContext);
+    const access = projectId
+        ? hasAccess(permission, projectId)
+        : hasAccess(permission);
+
+    const tooltipText = access
+        ? tooltip
+        : "You don't have access to perform this operation";
+
+    return (
+        <Tooltip title={tooltipText} arrow>
+            <span>
+                <Switch onChange={onChange} disabled={disabled || !access} {...rest} />
+            </span>
+        </Tooltip>
+    )
+}
+
+export default PermissionSwitch;

--- a/src/component/feature/FeatureToggleListNew/FeatureToggleListNewItem/FeatureToggleListNewItem.tsx
+++ b/src/component/feature/FeatureToggleListNew/FeatureToggleListNewItem/FeatureToggleListNewItem.tsx
@@ -1,5 +1,5 @@
-import { useContext, useRef } from 'react';
-import { Switch, TableCell, TableRow } from '@material-ui/core';
+import { useRef } from 'react';
+import { TableCell, TableRow } from '@material-ui/core';
 import { useHistory } from 'react-router';
 
 import { useStyles } from '../FeatureToggleListNew.styles';
@@ -15,7 +15,7 @@ import classNames from 'classnames';
 import CreatedAt from './CreatedAt';
 import useProject from '../../../../hooks/api/getters/useProject/useProject';
 import { UPDATE_FEATURE } from '../../../providers/AccessProvider/permissions';
-import AccessContext from '../../../../contexts/AccessContext';
+import PermissionSwitch from '../../../common/PermissionSwitch/PermissionSwitch';
 
 interface IFeatureToggleListNewItemProps {
     name: string;
@@ -34,7 +34,6 @@ const FeatureToggleListNewItem = ({
     projectId,
     createdAt,
 }: IFeatureToggleListNewItemProps) => {
-    const { hasAccess } = useContext(AccessContext);
     const { toast, setToastData } = useToast();
     const { toggleFeatureByEnvironment } = useToggleFeatureByEnv(
         projectId,
@@ -127,11 +126,10 @@ const FeatureToggleListNewItem = ({
                             key={env.name}
                         >
                             <span data-loading style={{ display: 'block' }}>
-                                <Switch
+                                <PermissionSwitch
                                     checked={env.enabled}
-                                    disabled={
-                                        !hasAccess(UPDATE_FEATURE, projectId)
-                                    }
+                                    projectId={projectId}
+                                    permission={UPDATE_FEATURE}
                                     ref={ref}
                                     onClick={handleToggle.bind(this, env)}
                                 />

--- a/src/component/feature/FeatureView2/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
+++ b/src/component/feature/FeatureView2/FeatureOverview/FeatureOverviewMetaData/FeatureOverviewMetaData.tsx
@@ -9,6 +9,8 @@ import { useStyles } from './FeatureOverviewMetadata.styles';
 
 import { Edit } from '@material-ui/icons';
 import { IFeatureViewParams } from '../../../../../interfaces/params';
+import PermissionIconButton from '../../../../common/PermissionIconButton/PermissionIconButton';
+import { UPDATE_FEATURE } from '../../../../providers/AccessProvider/permissions';
 
 const FeatureOverviewMetaData = () => {
     const styles = useStyles();
@@ -39,12 +41,14 @@ const FeatureOverviewMetaData = () => {
                             <div>Description:</div>
                             <div className={styles.descriptionContainer}>
                                 <p>{description}</p>
-                                <IconButton
+                                <PermissionIconButton
+                                    projectId={projectId}
+                                    permission={UPDATE_FEATURE}
                                     component={Link}
                                     to={`/projects/${projectId}/features2/${featureId}/settings`}
                                 >
                                     <Edit />
-                                </IconButton>
+                                </PermissionIconButton>
                             </div>
                         </span>
                     }

--- a/src/component/feature/FeatureView2/FeatureVariants/FeatureVariantsList/AddFeatureVariant/AddFeatureVariant.tsx
+++ b/src/component/feature/FeatureView2/FeatureVariants/FeatureVariantsList/AddFeatureVariant/AddFeatureVariant.tsx
@@ -4,7 +4,6 @@ import {
     FormControl,
     FormControlLabel,
     Grid,
-    Switch,
     TextField,
     InputAdornment,
     Button,
@@ -20,6 +19,8 @@ import GeneralSelect from '../../../../../common/GeneralSelect/GeneralSelect';
 import { useCommonStyles } from '../../../../../../common.styles';
 import Dialogue from '../../../../../common/Dialogue';
 import { trim, modalStyles } from '../../../../../common/util';
+import PermissionSwitch from '../../../../../common/PermissionSwitch/PermissionSwitch';
+import { UPDATE_FEATURE } from '../../../../../providers/AccessProvider/permissions';
 
 const payloadOptions = [
     { key: 'string', label: 'string' },
@@ -242,7 +243,8 @@ const AddVariant = ({
                         <FormControl>
                             <FormControlLabel
                                 control={
-                                    <Switch
+                                    <PermissionSwitch
+                                        permission={UPDATE_FEATURE}
                                         name="weightType"
                                         checked={isFixWeight}
                                         data-test={'VARIANT_WEIGHT_TYPE'}

--- a/src/component/feature/FeatureView2/FeatureViewEnvironment/FeatureViewEnvironment.tsx
+++ b/src/component/feature/FeatureView2/FeatureViewEnvironment/FeatureViewEnvironment.tsx
@@ -1,17 +1,18 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Cloud } from '@material-ui/icons';
-import { useParams, Link } from 'react-router-dom';
-import { Switch, Tooltip } from '@material-ui/core';
+import { Link, useParams } from 'react-router-dom';
+import { Tooltip } from '@material-ui/core';
 import classNames from 'classnames';
 import ConditionallyRender from '../../../common/ConditionallyRender';
 import useFeatureApi from '../../../../hooks/api/actions/useFeatureApi/useFeatureApi';
 import useToast from '../../../../hooks/useToast';
-import { FC } from 'react';
 import { IFeatureEnvironment } from '../../../../interfaces/featureToggle';
 import { IFeatureViewParams } from '../../../../interfaces/params';
 
 import { useStyles } from './FeatureViewEnvironment.styles';
 import useFeature from '../../../../hooks/api/getters/useFeature/useFeature';
+import PermissionSwitch from '../../../common/PermissionSwitch/PermissionSwitch';
+import { UPDATE_FEATURE } from '../../../providers/AccessProvider/permissions';
 
 interface IFeatureViewEnvironmentProps {
     env: IFeatureEnvironment;
@@ -115,7 +116,9 @@ const FeatureViewEnvironment: FC<IFeatureViewEnvironmentProps> = ({
                         condition={env?.strategies?.length > 0}
                         show={
                             <div className={styles.textContainer}>
-                                <Switch
+                                <PermissionSwitch
+                                    projectId={projectId}
+                                    permission={UPDATE_FEATURE}
                                     value={env.enabled}
                                     checked={env.enabled}
                                     onChange={toggleEnvironment}

--- a/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
+++ b/src/component/project/ProjectEnvironment/ProjectEnvironment.tsx
@@ -1,10 +1,9 @@
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 import ConditionallyRender from '../../common/ConditionallyRender';
 import { useStyles } from './ProjectEnvironment.styles';
 
 import useLoading from '../../../hooks/useLoading';
 import PageContent from '../../common/PageContent';
-import AccessContext from '../../../contexts/AccessContext';
 import HeaderTitle from '../../common/HeaderTitle';
 import { UPDATE_PROJECT } from '../../providers/AccessProvider/permissions';
 
@@ -13,11 +12,12 @@ import useToast from '../../../hooks/useToast';
 import useUiConfig from '../../../hooks/api/getters/useUiConfig/useUiConfig';
 import useEnvironments from '../../../hooks/api/getters/useEnvironments/useEnvironments';
 import useProject from '../../../hooks/api/getters/useProject/useProject';
-import { FormControlLabel, FormGroup, Switch } from '@material-ui/core';
+import { FormControlLabel, FormGroup } from '@material-ui/core';
 import useProjectApi from '../../../hooks/api/actions/useProjectApi/useProjectApi';
 import EnvironmentDisableConfirm from './EnvironmentDisableConfirm/EnvironmentDisableConfirm';
 import { Link } from 'react-router-dom';
 import { Alert } from '@material-ui/lab';
+import PermissionSwitch from '../../common/PermissionSwitch/PermissionSwitch';
 
 export interface ProjectEnvironment {
     name: string;
@@ -29,8 +29,6 @@ interface ProjectEnvironmentListProps {
 }
 
 const ProjectEnvironmentList = ({ projectId }: ProjectEnvironmentListProps) => {
-    const { hasAccess } = useContext(AccessContext);
-
     // api state
     const { toast, setToastData } = useToast();
     const { uiConfig } = useUiConfig();
@@ -126,8 +124,6 @@ const ProjectEnvironmentList = ({ projectId }: ProjectEnvironmentListProps) => {
         enabled: project?.environments.includes(e.name),
     }));
 
-    const hasPermission = hasAccess(UPDATE_PROJECT, projectId);
-
     const genLabel = (env: ProjectEnvironment) => (
         <>
             <code>{env.name}</code> environment is{' '}
@@ -143,9 +139,11 @@ const ProjectEnvironmentList = ({ projectId }: ProjectEnvironmentListProps) => {
                         key={env.name}
                         label={genLabel(env)}
                         control={
-                            <Switch
+                            <PermissionSwitch
+                                tooltip={`${env.enabled ? 'Disable' : 'Enable'} environment`}
                                 size="medium"
-                                disabled={!hasPermission}
+                                projectId={projectId}
+                                permission={UPDATE_PROJECT}
                                 checked={env.enabled}
                                 onChange={toggleEnv.bind(this, env)}
                             />

--- a/src/component/strategies/StrategiesList/StrategiesList.jsx
+++ b/src/component/strategies/StrategiesList/StrategiesList.jsx
@@ -4,27 +4,10 @@ import classnames from 'classnames';
 import { Link, useHistory } from 'react-router-dom';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
-import {
-    List,
-    ListItem,
-    ListItemAvatar,
-    IconButton,
-    ListItemText,
-    Button,
-    Tooltip,
-} from '@material-ui/core';
-import {
-    Add,
-    Visibility,
-    VisibilityOff,
-    Delete,
-    Extension,
-} from '@material-ui/icons';
+import { IconButton, List, ListItem, ListItemAvatar, ListItemText, Tooltip } from '@material-ui/core';
+import { Add, Delete, Extension, Visibility, VisibilityOff } from '@material-ui/icons';
 
-import {
-    CREATE_STRATEGY,
-    DELETE_STRATEGY,
-} from '../../providers/AccessProvider/permissions';
+import { CREATE_STRATEGY, DELETE_STRATEGY, UPDATE_STRATEGY } from '../../providers/AccessProvider/permissions';
 
 import ConditionallyRender from '../../common/ConditionallyRender/ConditionallyRender';
 import PageContent from '../../common/PageContent/PageContent';
@@ -34,6 +17,8 @@ import { useStyles } from './styles';
 import AccessContext from '../../../contexts/AccessContext';
 import Dialogue from '../../common/Dialogue';
 import { ADD_NEW_STRATEGY_ID } from '../../../testIds';
+import PermissionIconButton from '../../common/PermissionIconButton/PermissionIconButton';
+import PermissionButton from '../../common/PermissionButton/PermissionButton';
 
 const StrategiesList = ({
     strategies,
@@ -60,26 +45,29 @@ const StrategiesList = ({
                 <ConditionallyRender
                     condition={smallScreen}
                     show={
-                        <Tooltip title="Add new strategy">
-                            <IconButton
+                            <PermissionIconButton
                                 data-test={ADD_NEW_STRATEGY_ID}
                                 onClick={() =>
                                     history.push('/strategies/create')
                                 }
+                                permission={CREATE_STRATEGY}
+                                tooltip={'Add new strategy'}
                             >
                                 <Add />
-                            </IconButton>
-                        </Tooltip>
+                            </PermissionIconButton>
+
                     }
                     elseShow={
-                        <Button
+                        <PermissionButton
                             onClick={() => history.push('/strategies/create')}
                             color="primary"
+                            permission={CREATE_STRATEGY}
                             variant="contained"
                             data-test={ADD_NEW_STRATEGY_ID}
+                            tooltip={'Add new strategy'}
                         >
                             Add new strategy
-                        </Button>
+                        </PermissionButton>
                     }
                 />
             }
@@ -98,7 +86,7 @@ const StrategiesList = ({
 
     const reactivateButton = strategy => (
         <Tooltip title="Reactivate activation strategy">
-            <IconButton
+            <PermissionIconButton
                 onClick={() =>
                     setDialogueMetaData({
                         show: true,
@@ -106,9 +94,9 @@ const StrategiesList = ({
                         onConfirm: () => reactivateStrategy(strategy),
                     })
                 }
-            >
-                <Visibility />
-            </IconButton>
+                permission={UPDATE_STRATEGY}
+                tooltip={'Reactivate activation strategy'}
+            ><VisibilityOff /></PermissionIconButton>
         </Tooltip>
     );
 
@@ -119,28 +107,28 @@ const StrategiesList = ({
                 <Tooltip title="You cannot deprecate the default strategy">
                     <div>
                         <IconButton disabled>
-                            <VisibilityOff />
+                            <Visibility />
                         </IconButton>
                     </div>
                 </Tooltip>
             }
             elseShow={
-                <Tooltip title="Deprecate activation strategy">
-                    <div>
-                        <IconButton
-                            onClick={() =>
-                                setDialogueMetaData({
-                                    show: true,
-                                    title: 'Really deprecate strategy?',
-                                    onConfirm: () =>
-                                        deprecateStrategy(strategy),
-                                })
-                            }
-                        >
-                            <VisibilityOff />
-                        </IconButton>
-                    </div>
-                </Tooltip>
+                <div>
+                    <PermissionIconButton
+                        onClick={() =>
+                            setDialogueMetaData({
+                                show: true,
+                                title: 'Really deprecate strategy?',
+                                onConfirm: () =>
+                                    deprecateStrategy(strategy),
+                            })
+                        }
+                        permission={UPDATE_STRATEGY}
+                        tooltip={'Deprecate activation strategy'}
+                    >
+                        <Visibility />
+                    </PermissionIconButton>
+                </div>
             }
         />
     );
@@ -149,8 +137,7 @@ const StrategiesList = ({
         <ConditionallyRender
             condition={strategy.editable}
             show={
-                <Tooltip title="Delete strategy">
-                    <IconButton
+                    <PermissionIconButton
                         onClick={() =>
                             setDialogueMetaData({
                                 show: true,
@@ -158,10 +145,11 @@ const StrategiesList = ({
                                 onConfirm: () => removeStrategy(strategy),
                             })
                         }
+                        permission={DELETE_STRATEGY}
+                        tooltip={'Delete strategy'}
                     >
                         <Delete />
-                    </IconButton>
-                </Tooltip>
+                    </PermissionIconButton>
             }
             elseShow={
                 <Tooltip title="You cannot delete a built-in strategy">

--- a/src/component/strategies/__tests__/__snapshots__/list-component-test.jsx.snap
+++ b/src/component/strategies/__tests__/__snapshots__/list-component-test.jsx.snap
@@ -81,53 +81,52 @@ exports[`renders correctly with one strategy 1`] = `
             another's description
           </p>
         </div>
-        <div
-          aria-describedby={null}
-          className=""
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          onTouchEnd={[Function]}
-          onTouchStart={[Function]}
-          title="Deprecate activation strategy"
-        >
-          <button
-            className="MuiButtonBase-root MuiIconButton-root"
-            disabled={false}
+        <div>
+          <span
+            aria-describedby={null}
+            className=""
             onBlur={[Function]}
-            onClick={[Function]}
-            onDragLeave={[Function]}
             onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
             onMouseLeave={[Function]}
-            onMouseUp={[Function]}
+            onMouseOver={[Function]}
             onTouchEnd={[Function]}
-            onTouchMove={[Function]}
             onTouchStart={[Function]}
-            tabIndex={0}
-            type="button"
+            title="You don't have access to perform this operation"
           >
-            <span
-              className="MuiIconButton-label"
+            <button
+              className="MuiButtonBase-root MuiIconButton-root Mui-disabled Mui-disabled"
+              disabled={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <span
+                className="MuiIconButton-label"
               >
-                <path
-                  d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </button>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </span>
         </div>
       </li>
     </ul>
@@ -164,34 +163,49 @@ exports[`renders correctly with one strategy without permissions 1`] = `
       <div
         className="makeStyles-headerActions-9"
       >
-        <button
-          className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-          data-test="ADD_NEW_STRATEGY_ID"
-          disabled={false}
+        <span
+          aria-describedby={null}
+          className=""
           onBlur={[Function]}
-          onClick={[Function]}
-          onDragLeave={[Function]}
           onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
           onMouseLeave={[Function]}
-          onMouseUp={[Function]}
+          onMouseOver={[Function]}
           onTouchEnd={[Function]}
-          onTouchMove={[Function]}
           onTouchStart={[Function]}
-          tabIndex={0}
-          type="button"
+          title="Add new strategy"
         >
-          <span
-            className="MuiButton-label"
+          <button
+            className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+            data-test="ADD_NEW_STRATEGY_ID"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
           >
-            Add new strategy
-          </span>
-          <span
-            className="MuiTouchRipple-root"
-          />
-        </button>
+            <span
+              className="MuiButton-label"
+            >
+              Add new strategy
+              <span
+                className="MuiButton-endIcon MuiButton-iconSizeMedium"
+              />
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
+        </span>
       </div>
     </div>
   </div>
@@ -245,53 +259,55 @@ exports[`renders correctly with one strategy without permissions 1`] = `
             another's description
           </p>
         </div>
-        <div
-          aria-describedby={null}
-          className=""
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onMouseLeave={[Function]}
-          onMouseOver={[Function]}
-          onTouchEnd={[Function]}
-          onTouchStart={[Function]}
-          title="Deprecate activation strategy"
-        >
-          <button
-            className="MuiButtonBase-root MuiIconButton-root"
-            disabled={false}
+        <div>
+          <span
+            aria-describedby={null}
+            className=""
             onBlur={[Function]}
-            onClick={[Function]}
-            onDragLeave={[Function]}
             onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
             onMouseLeave={[Function]}
-            onMouseUp={[Function]}
+            onMouseOver={[Function]}
             onTouchEnd={[Function]}
-            onTouchMove={[Function]}
             onTouchStart={[Function]}
-            tabIndex={0}
-            type="button"
+            title="Deprecate activation strategy"
           >
-            <span
-              className="MuiIconButton-label"
+            <button
+              className="MuiButtonBase-root MuiIconButton-root"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              tabIndex={0}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <span
+                className="MuiIconButton-label"
               >
-                <path
-                  d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </button>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                  />
+                </svg>
+              </span>
+              <span
+                className="MuiTouchRipple-root"
+              />
+            </button>
+          </span>
         </div>
         <div
           aria-describedby={null}


### PR DESCRIPTION
- This adds a generic way to control permission to mutations in the same
  way as our PermissionButton and PermissionIconButton already does.

- This also switches the StrategiesList to use PermissionIconButton so
  users without ADMIN role do not believe they can deprecate/reactivate
  strategies.