### PR TITLE
fix: add outlined for username login input and fix eye icon padding

### DIFF
--- a/src/component/common/PasswordField/PasswordField.tsx
+++ b/src/component/common/PasswordField/PasswordField.tsx
@@ -22,7 +22,7 @@ const PasswordField = ({ ...rest }) => {
             type={showPassword ? 'text' : 'password'}
             InputProps={{
                 style: {
-                    paddingRight: '0px !important',
+                    paddingRight: '0px',
                 },
                 endAdornment: (
                     <InputAdornment position="end">

--- a/src/component/user/PasswordAuth/PasswordAuth.jsx
+++ b/src/component/user/PasswordAuth/PasswordAuth.jsx
@@ -114,6 +114,8 @@ const PasswordAuth = ({ authDetails, passwordLogin }) => {
                                 helperText={usernameError}
                                 autoComplete="true"
                                 data-test={LOGIN_EMAIL_ID}
+                                variant="outlined"
+                                size="small"
                             />
                             <PasswordField
                                 label="Password"


### PR DESCRIPTION
![Screen Shot 2022-01-09 at 12 11 31 PM](https://user-images.githubusercontent.com/47088512/148679769-4adfe881-bf76-425e-8c0f-a96e1cc291d6.png)
