### PR TITLE
docs(readme): remove travis badge; small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-[![Build Status](https://travis-ci.org/Unleash/unleash-frontend.svg?branch=main)](https://travis-ci.org/Unleash/unleash-frontend)
-
 # Developing
 
-### Why did you render
+## Why did you render
 
 This application is set up with [WDYR](https://github.com/welldone-software/why-did-you-render) and [craco](https://github.com/gsoft-inc/craco) in order to find, debug and remove uneccesary re-renders. This configuration can be found in /src/wdyr.ts.
 
@@ -19,7 +17,7 @@ if (process.env.NODE_ENV === 'development') {
 
 Now you should be able to review rendering information in the console. If you do utilise this functionality, please remember to set the configuration back to spare other developers the noise in the console.
 
-### Run with together with local unleash-api:
+## Run with a local instance of the unleash-api:
 
 You need to first start the unleash-api on port 4242
 before you can start working on unleash-frontend.
@@ -31,7 +29,7 @@ yarn install
 yarn run start
 ```
 
-### Run with heroku hosted unleash-api:
+## Run with a heroku-hosted unleash-api:
 
 ```bash
 cd ~/unleash-frontend


### PR DESCRIPTION
This commit removes the Travis badge (we haven't built with Travis for a year!) and adds a few small wording and structural fixes.