### PR TITLE
fix: use correct path for create feature link

### DIFF
--- a/src/component/common/ListPlaceholder/ListPlaceholder.tsx
+++ b/src/component/common/ListPlaceholder/ListPlaceholder.tsx
@@ -17,7 +17,7 @@ const ListPlaceholder = ({ text, link, linkText }: IListPlaceholderProps) => {
             {text}
             <ConditionallyRender
                 condition={Boolean(link && linkText)}
-                show={<Link to="/features/create">Add your first toggle</Link>}
+                show={<Link to={link}>Add your first toggle</Link>}
             />
         </ListItem>
     );


### PR DESCRIPTION
Makes this link work:

![image](https://user-images.githubusercontent.com/6271/151954163-05c4b51d-698f-4790-8758-149707a5c1cd.png)
