### PR TITLE
fix: make sure we handle hours as 00-23

### DIFF
--- a/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -8,9 +8,9 @@ interface IDateSingleValueProps {
     setError: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const parseValue = (value: string) => {
+export const parseDateValue = (value: string) => {
     const date = new Date(value);
-    return format(date, 'yyyy-MM-dd') + 'T' + format(date, 'kk:mm');
+    return format(date, 'yyyy-MM-dd') + 'T' + format(date, 'HH:mm');
 };
 
 export const DateSingleValue = ({
@@ -28,7 +28,7 @@ export const DateSingleValue = ({
                 id="date"
                 label="Date"
                 type="datetime-local"
-                value={parseValue(value)}
+                value={parseDateValue(value)}
                 onChange={e => {
                     setError('');
                     setValue(new Date(e.target.value).toISOString());

--- a/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/__tests__/__snapshots__/date-single-value-test.tsx.snap
+++ b/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/__tests__/__snapshots__/date-single-value-test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Date component - snapshot matching 1`] = `
+Object {
+  "midday": "2022-03-15T12:00",
+  "midnight": "2022-03-15T00:00",
+}
+`;

--- a/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/__tests__/date-single-value-test.tsx
+++ b/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/__tests__/date-single-value-test.tsx
@@ -1,0 +1,18 @@
+import { parseDateValue } from '../DateSingleValue';
+
+test(`Date component is able to parse midnight when it's 00`, () => {
+    let f = parseDateValue('2022-03-15T12:27');
+    let midnight = parseDateValue('2022-03-15T00:27');
+    expect(f).toEqual('2022-03-15T12:27');
+    expect(midnight).toEqual('2022-03-15T00:27');
+});
+
+test(`Date component - snapshot matching`, () => {
+    let midnight = '2022-03-15T00:00';
+    let midday = '2022-03-15T12:00';
+    let obj = {
+        midnight: parseDateValue(midnight),
+        midday: parseDateValue(midday),
+    };
+    expect(obj).toMatchSnapshot();
+});


### PR DESCRIPTION
So we were using date-fn's format library with `kk` which handles hours as 01-24, instead of HH which is 00-23.