### PR TITLE
feat: make DATE_AFTER the default time operator

### DIFF
--- a/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditHeader/ConstraintAccordionEditHeader.tsx
+++ b/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditHeader/ConstraintAccordionEditHeader.tsx
@@ -9,7 +9,7 @@ import ConditionallyRender from '../../../ConditionallyRender';
 import {
     allOperators,
     dateOperators,
-    DATE_BEFORE,
+    DATE_AFTER,
     IN,
 } from '../../../../../constants/operators';
 import { SAVE } from '../ConstraintAccordionEdit';
@@ -56,7 +56,7 @@ export const ConstraintAccordionEditHeader = ({
         ) {
             setLocalConstraint(prev => ({
                 ...prev,
-                operator: DATE_BEFORE,
+                operator: DATE_AFTER,
                 value: new Date().toISOString(),
             }));
         } else if (


### PR DESCRIPTION
Change the default date-based operator to DATE_AFTER instead of to DATE_BEFORE.

The reasoning is two-fold:
- I (we?) imagine it'll be more common to schedule a feature to be released _after_ a point in time, than to make it available _until_ some point in time.
- DATE_AFTER is the first item in the list, so it makes sense to use that as the default choice anyway