### PR TITLE
use relative path for api

### DIFF
--- a/src/component/providers/SWRProvider/SWRProvider.tsx
+++ b/src/component/providers/SWRProvider/SWRProvider.tsx
@@ -30,10 +30,10 @@ const SWRProvider: React.FC<ISWRProviderProps> = ({
             }
 
             if (
-                path === formatApiPath('login') ||
-                path === formatApiPath('new-user') ||
-                path === formatApiPath('reset-password') ||
-                path === formatApiPath('forgotten-password')
+                path === formatApiPath('/login') ||
+                path === formatApiPath('/new-user') ||
+                path === formatApiPath('/reset-password') ||
+                path === formatApiPath('/forgotten-password')
             ) {
                 return;
             }

--- a/src/utils/formatPath.ts
+++ b/src/utils/formatPath.ts
@@ -37,7 +37,7 @@ export const formatApiPath = (path: string) => {
     if (basePath) {
         return `${basePath}/${path}`;
     }
-    return `/${path}`;
+    return path;
 };
 
 export const formatAssetPath = (path: string) => {


### PR DESCRIPTION
Our company has unleash running behind a reverse proxy server, so unleash api endpoints are at https://mydomain.com/unleash/api/*
With the formatApiPath function returning absolute path, the front end is trying to reach unleash apis at https://mydomain/api/*, casuing front end unable to load as it cannot reach unleash apis.

Api path formatting should follow the same way as formatting asset path.