### PR TITLE
refactor: remove default link color

### DIFF
--- a/src/themes/app.css
+++ b/src/themes/app.css
@@ -133,6 +133,10 @@ p {
     padding: 0;
 }
 
+a {
+    color: inherit;
+}
+
 #app {
     height: 100%;
 }


### PR DESCRIPTION
Makes links match their parent by default.

![image](https://user-images.githubusercontent.com/6271/164229954-2507dd90-a5e1-40d5-a2fc-1acf890830cf.png)
