### PR TITLE
feat: example implementation of sortable table interfaces

### DIFF
--- a/src/component/common/SortableTable/ExampleTable.tsx
+++ b/src/component/common/SortableTable/ExampleTable.tsx
@@ -1,0 +1,86 @@
+import { Box, Table, TableBody, TableCell, TableRow } from '@material-ui/core';
+import { useDataFilter } from 'hooks/useDataFilter';
+import {
+    useSortableTablesData,
+    SortableHeader,
+} from 'hooks/useSortableTablesData';
+import { objectId } from 'utils/objectId';
+import { TableCellSortable } from './TableCellSortable/TableCellSortable';
+import { TableHeader } from './TableHeader';
+
+const dummyData = [
+    { type: 'chocolate', cost: 15, merchant: 'Bobs icecream' },
+    { type: 'vanilla', cost: 15, merchant: 'Bobs icecream' },
+    { type: 'strawberry', cost: 15, merchant: 'Bobs icecream' },
+    { type: 'nutella', cost: 15, merchant: 'Bobs icecream' },
+];
+
+const getSortableData = (data: any, headers: SortableHeader[]) => {
+    let tableData: any = [];
+
+    tableData = data.map((dataItem: any) => {
+        let filtered: { [index: string]: string } = {};
+
+        headers.forEach(header => {
+            filtered[header.name] = dataItem[header.name];
+        });
+
+        return filtered;
+    });
+
+    return { headers, data: tableData };
+};
+
+export const ExampleTable = () => {
+    const { headers, data } = getSortableData(dummyData, [
+        { name: 'type', onClick: 'text' },
+        { name: 'merchant', onClick: 'text' },
+    ]);
+
+    const { headerData, tableData, setData, sortMetaData } =
+        useSortableTablesData(headers, data);
+
+    // TODO: Use filters in filter UI
+    const { filteredData, filters } = useDataFilter(
+        tableData,
+        ['type', 'merchant'],
+        setData
+    );
+
+    const renderHeaders = () => {
+        return headerData.map((header: any) => {
+            return (
+                <TableCellSortable
+                    key={header.name}
+                    name={header.name}
+                    sort={sortMetaData.type}
+                    setSort={header.onClick}
+                >
+                    {header.name}
+                </TableCellSortable>
+            );
+        });
+    };
+
+    const renderBody = () => {
+        return filteredData.map((data: any) => {
+            return (
+                <TableRow key={objectId(data)}>
+                    <TableCell>{data.type}</TableCell>
+                    <TableCell>{data.merchant}</TableCell>
+                </TableRow>
+            );
+        });
+    };
+
+    return (
+        <Box
+            style={{ background: '#fff', borderRadius: '5px', padding: '1rem' }}
+        >
+            <Table>
+                <TableHeader>{renderHeaders()}</TableHeader>
+                <TableBody>{renderBody()}</TableBody>
+            </Table>
+        </Box>
+    );
+};

--- a/src/component/common/SortableTable/TableCellSortable/TableCellSortable.styles.ts
+++ b/src/component/common/SortableTable/TableCellSortable/TableCellSortable.styles.ts
@@ -1,0 +1,31 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles(theme => ({
+    tableCellHeaderSortable: {
+        cursor: 'pointer',
+        '&:hover': {
+            backgroundColor: theme.v2.palette.grey[40],
+            '& > svg': {
+                color: theme.v2.palette.grey[90],
+            },
+        },
+        '& > svg': {
+            fontSize: theme.v2.fontSizes.headerIcon,
+            verticalAlign: 'middle',
+            color: theme.v2.palette.grey[70],
+            marginLeft: '4px',
+        },
+        '&.sorted': {
+            fontWeight: 'bold',
+            '& > svg': {
+                color: theme.v2.palette.grey[90],
+            },
+        },
+    },
+    sortButton: {
+        all: 'unset',
+        '&:focus-visible, &:active': {
+            outline: 'revert',
+        },
+    },
+}));

--- a/src/component/common/SortableTable/TableCellSortable/TableCellSortable.tsx
+++ b/src/component/common/SortableTable/TableCellSortable/TableCellSortable.tsx
@@ -1,0 +1,77 @@
+import React, { ReactNode, useContext } from 'react';
+import { TableCell } from '@material-ui/core';
+import classnames from 'classnames';
+import {
+    UnfoldMoreOutlined,
+    KeyboardArrowDown,
+    KeyboardArrowUp,
+} from '@material-ui/icons';
+import { IUsersSort, UsersSortType } from 'hooks/useUsersSort';
+import ConditionallyRender from 'component/common/ConditionallyRender';
+import { useStyles } from 'component/common/Table/TableCellSortable/TableCellSortable.styles';
+import { AnnouncerContext } from 'component/common/Announcer/AnnouncerContext/AnnouncerContext';
+
+// Add others as needed, e.g. UsersSortType | FeaturesSortType
+type SortType = UsersSortType;
+type Sort = IUsersSort;
+
+interface ITableCellSortableProps {
+    className?: string;
+    name: SortType;
+    sort: Sort;
+    setSort: React.Dispatch<React.SetStateAction<Sort>>;
+    children: ReactNode;
+}
+
+export const TableCellSortable = ({
+    className,
+    name,
+    sort,
+    setSort,
+    children,
+}: ITableCellSortableProps) => {
+    const { setAnnouncement } = useContext(AnnouncerContext);
+    const styles = useStyles();
+
+    const ariaSort =
+        sort.type === name
+            ? sort.desc
+                ? 'descending'
+                : 'ascending'
+            : undefined;
+
+    const cellClassName = classnames(
+        className,
+        styles.tableCellHeaderSortable,
+        sort.type === name && 'sorted'
+    );
+
+    const onSortClick = () => {
+        setSort(prev => ({
+            desc: !Boolean(prev.desc),
+            type: name,
+        }));
+        setAnnouncement(
+            `Sorted table by ${name}, ${sort.desc ? 'ascending' : 'descending'}`
+        );
+    };
+
+    return (
+        <TableCell aria-sort={ariaSort} className={cellClassName}>
+            <button className={styles.sortButton} onClick={onSortClick}>
+                {children}
+            </button>
+            <ConditionallyRender
+                condition={sort.type === name}
+                show={
+                    <ConditionallyRender
+                        condition={Boolean(sort.desc)}
+                        show={<KeyboardArrowDown />}
+                        elseShow={<KeyboardArrowUp />}
+                    />
+                }
+                elseShow={<UnfoldMoreOutlined />}
+            />
+        </TableCell>
+    );
+};

--- a/src/component/common/SortableTable/TableHeader.styles.ts
+++ b/src/component/common/SortableTable/TableHeader.styles.ts
@@ -1,0 +1,19 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles(theme => ({
+    tableHeader: {
+        '& > th': {
+            backgroundColor: theme.v2.palette.grey[20],
+            fontWeight: 'normal',
+            border: 0,
+            '&:first-child': {
+                borderTopLeftRadius: '8px',
+                borderBottomLeftRadius: '8px',
+            },
+            '&:last-child': {
+                borderTopRightRadius: '8px',
+                borderBottomRightRadius: '8px',
+            },
+        },
+    },
+}));

--- a/src/component/common/SortableTable/TableHeader.tsx
+++ b/src/component/common/SortableTable/TableHeader.tsx
@@ -1,0 +1,12 @@
+import { TableHead, TableRow } from '@material-ui/core';
+import { FC } from 'react';
+import { useStyles } from './TableHeader.styles';
+
+export const TableHeader: FC = ({ children }) => {
+    const styles = useStyles();
+    return (
+        <TableHead>
+            <TableRow className={styles.tableHeader}>{children}</TableRow>
+        </TableHead>
+    );
+};

--- a/src/component/menu/routes.ts
+++ b/src/component/menu/routes.ts
@@ -51,6 +51,7 @@ import { CreateSegment } from 'component/segments/CreateSegment/CreateSegment';
 import { EditSegment } from 'component/segments/EditSegment/EditSegment';
 import { SegmentsList } from 'component/segments/SegmentList/SegmentList';
 import { IRoute } from 'interfaces/route';
+import { ExampleTable } from 'component/common/SortableTable/ExampleTable';
 
 export const routes: IRoute[] = [
     // Splash
@@ -58,6 +59,15 @@ export const routes: IRoute[] = [
         path: '/splash/:splashId',
         title: 'Unleash',
         component: SplashPage,
+        type: 'protected',
+        menu: {},
+    },
+
+    // Example table
+    {
+        path: '/example-table',
+        title: 'Unleash',
+        component: ExampleTable,
         type: 'protected',
         menu: {},
     },

--- a/src/hooks/useDataFilter.ts
+++ b/src/hooks/useDataFilter.ts
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+
+export const useDataFilter = (
+    data: any,
+    filters: string[],
+    setter: React.SetStateAction<React.Dispatch<any>>
+) => {
+    // setup filter state
+    // return out filter functions to use in UI
+    // filter data
+
+    const filter = (data: any) => {
+        return data;
+    };
+
+    const changeFilterState = () => {
+        // change state for filter
+    };
+
+    return {
+        filteredData: filter(data),
+        filters: [{ name: 'merchant', onClick: changeFilterState }],
+    };
+};

--- a/src/hooks/useSortableTablesData.ts
+++ b/src/hooks/useSortableTablesData.ts
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+type SortableHeaderFunctionName = 'text' | 'date';
+
+export type SortableHeader = {
+    name: string;
+    onClick: SortableHeaderFunctionName | (() => void);
+};
+
+const getFirstArrayItem = (data: any[]) => {
+    if (data.length > 0) {
+        return data[0];
+    }
+};
+
+export const useSortableTablesData = (
+    headers: SortableHeader[],
+    tableData: any
+) => {
+    const [data, setData] = useState(tableData);
+
+    const [sortMetaData, setSortMetaData] = useState({
+        desc: true,
+        type: getFirstArrayItem(data).name || '',
+    });
+
+    const createHeaderData = () => {
+        return headers.map(header => ({
+            ...header,
+            onClick: getSortFunction(header),
+        }));
+    };
+
+    const sortByText = () => {
+        console.log("I'm sorting by text");
+
+        setData((prev: any) => prev);
+        setSortMetaData(prev => ({ desc: !prev.desc, type: 'text' }));
+    };
+
+    const sortByDate = () => {
+        console.log("I'm sorting by date");
+
+        setData((prev: any) => prev);
+        setSortMetaData(prev => ({ desc: !prev.desc, type: 'date' }));
+    };
+
+    const getSortFunction = (header: SortableHeader) => {
+        if (header.onClick instanceof Function) {
+            return () => {
+                // @ts-expect-error
+                header.onClick();
+                setSortMetaData(prev => ({
+                    desc: !prev.desc,
+                    type: header.name,
+                }));
+            };
+        }
+
+        switch (header.onClick) {
+            case 'text':
+                return sortByText;
+            case 'date':
+                return sortByDate;
+        }
+    };
+
+    return {
+        headerData: createHeaderData(),
+        tableData: data,
+        setData,
+        sortMetaData,
+    };
+};


### PR DESCRIPTION
Experiment to find a reusable interface for sortable tables. Related to #908

Leverages the existing SortableTableCell interface that we've already used in UserList