### PR TITLE
fix: user search by text instead of regex

### DIFF
--- a/src/hooks/useUsersFilter.ts
+++ b/src/hooks/useUsersFilter.ts
@@ -44,11 +44,13 @@ const filterUsersByQuery = (users: IUser[], filter: IUsersFilter): IUser[] => {
     }
 
     return users.filter(user => {
-        const search = filter.query?.toLowerCase();
-        return filterUserByText(user, search);
+        return filterUserByText(user, filter.query);
     });
 };
 
-const filterUserByText = (user: IUser, search: string = ''): boolean =>
-    (user.name ?? '').toLowerCase().includes(search) ||
-    (user.username ?? user.email ?? '').toLowerCase().includes(search);
+const filterUserByText = (user: IUser, search: string = ''): boolean => {
+    const fieldsToSearch = [user.name ?? '', user.username ?? user.email ?? ''];
+    return fieldsToSearch.some(field =>
+        field.toLowerCase().includes(search.toLowerCase())
+    );
+};

--- a/src/hooks/useUsersFilter.ts
+++ b/src/hooks/useUsersFilter.ts
@@ -43,20 +43,12 @@ const filterUsersByQuery = (users: IUser[], filter: IUsersFilter): IUser[] => {
         return users;
     }
 
-    // Try to parse the search query as a RegExp.
-    // Return all users if it can't be parsed.
-    try {
-        const regExp = new RegExp(filter.query, 'i');
-        return users.filter(user => filterUserByRegExp(user, regExp));
-    } catch (err) {
-        if (err instanceof SyntaxError) {
-            return users;
-        } else {
-            throw err;
-        }
-    }
+    return users.filter(user => {
+        const search = filter.query?.toLowerCase();
+        return filterUserByText(user, search);
+    });
 };
 
-const filterUserByRegExp = (user: IUser, regExp: RegExp): boolean =>
-    regExp.test(user.name ?? '') ||
-    regExp.test(user.username ?? user.email ?? '');
+const filterUserByText = (user: IUser, search: string = ''): boolean =>
+    (user.name ?? '').toLowerCase().includes(search) ||
+    (user.username ?? user.email ?? '').toLowerCase().includes(search);


### PR DESCRIPTION
## About the changes
Downgrades the new user search to a basic text search, which should be more intuitive for end-users in most cases.