### PR TITLE
Feat/sticky name cell

### DIFF
--- a/src/component/common/PageContent/PageContent.tsx
+++ b/src/component/common/PageContent/PageContent.tsx
@@ -1,10 +1,11 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactNode, useRef } from 'react';
 import classnames from 'classnames';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import { Paper, PaperProps } from '@mui/material';
 import { useStyles } from './PageContent.styles';
 import useLoading from 'hooks/useLoading';
 import { ConditionallyRender } from '../ConditionallyRender/ConditionallyRender';
+import { useAsyncDebounce } from 'react-table';
 
 interface IPageContentProps extends PaperProps {
     header?: ReactNode;
@@ -18,6 +19,7 @@ interface IPageContentProps extends PaperProps {
      */
     disableBorder?: boolean;
     bodyClass?: string;
+    onScrollHandler?: (ref: HTMLDivElement | null) => void;
 }
 
 export const PageContent: FC<IPageContentProps> = ({
@@ -28,9 +30,11 @@ export const PageContent: FC<IPageContentProps> = ({
     bodyClass = '',
     isLoading = false,
     className,
+    onScrollHandler,
     ...rest
 }) => {
     const { classes: styles } = useStyles();
+    const scrollRef = useRef<HTMLDivElement | null>(null);
     const ref = useLoading(isLoading);
 
     const headerClasses = classnames(styles.headerContainer, {
@@ -47,6 +51,14 @@ export const PageContent: FC<IPageContentProps> = ({
     );
 
     const paperProps = disableBorder ? { elevation: 0 } : {};
+
+    const onScroll = () => {
+        if (onScrollHandler) {
+            onScrollHandler(scrollRef.current);
+        }
+    };
+
+    const debouncedScroll = useAsyncDebounce(onScroll, 50);
 
     return (
         <div ref={ref}>
@@ -67,7 +79,13 @@ export const PageContent: FC<IPageContentProps> = ({
                         </div>
                     }
                 />
-                <div className={bodyClasses}>{children}</div>
+                <div
+                    onScroll={debouncedScroll}
+                    ref={scrollRef}
+                    className={bodyClasses}
+                >
+                    {children}
+                </div>
             </Paper>
         </div>
     );

--- a/src/component/common/Table/SortableTableHeader/CellSortable/CellSortable.styles.ts
+++ b/src/component/common/Table/SortableTableHeader/CellSortable/CellSortable.styles.ts
@@ -40,9 +40,18 @@ export const useStyles = makeStyles()(theme => ({
         fontWeight: theme.fontWeight.bold,
     },
     label: {
+        display: 'flex',
+        flexDirection: 'column',
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
         overflowX: 'hidden',
         overflowY: 'visible',
+        '::after': {
+            fontWeight: 'bold',
+            display: 'inline-block',
+            height: 0,
+            content: 'attr(data-text)',
+            visibility: 'hidden',
+        },
     },
 }));

--- a/src/component/common/Table/SortableTableHeader/CellSortable/CellSortable.styles.ts
+++ b/src/component/common/Table/SortableTableHeader/CellSortable/CellSortable.styles.ts
@@ -52,6 +52,7 @@ export const useStyles = makeStyles()(theme => ({
             height: 0,
             content: 'attr(data-text)',
             visibility: 'hidden',
+            overflow: 'hidden',
         },
     },
 }));

--- a/src/component/common/Table/SortableTableHeader/CellSortable/CellSortable.tsx
+++ b/src/component/common/Table/SortableTableHeader/CellSortable/CellSortable.tsx
@@ -111,6 +111,7 @@ export const CellSortable: FC<ICellSortableProps> = ({
                                 className={styles.label}
                                 ref={ref}
                                 tabIndex={-1}
+                                data-text={children}
                             >
                                 {children}
                             </span>

--- a/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.styles.ts
+++ b/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.styles.ts
@@ -16,6 +16,17 @@ export const useStyles = makeStyles()(theme => ({
             },
         },
     },
+    innerContainer: {
+        position: 'absolute',
+        zIndex: 500,
+        backgroundColor: '#fff',
+        paddingTop: theme.spacing(1.5),
+        paddingBottom: theme.spacing(1.5),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2),
+        minWidth: '145px',
+        left: '50px',
+    },
     container: {
         display: 'flex',
         flexDirection: 'column',

--- a/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.styles.ts
+++ b/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.styles.ts
@@ -24,7 +24,7 @@ export const useStyles = makeStyles()(theme => ({
         paddingBottom: theme.spacing(1.5),
         paddingLeft: theme.spacing(2),
         paddingRight: theme.spacing(2),
-        minWidth: '145px',
+        width: '145px',
         left: '50px',
     },
     container: {

--- a/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.tsx
+++ b/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.tsx
@@ -10,14 +10,14 @@ interface IFeatureLinkCellProps {
     title?: string;
     to: string;
     subtitle?: string;
-    scrollAmount: number;
+    scrollAmount?: number;
 }
 
 export const FeatureLinkCell: FC<IFeatureLinkCellProps> = ({
     title,
     to,
     subtitle,
-    scrollAmount,
+    scrollAmount = 0,
 }) => {
     const { classes: styles } = useStyles();
     const search = useSearchHighlightContext();

--- a/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.tsx
+++ b/src/component/common/Table/cells/FeatureLinkCell/FeatureLinkCell.tsx
@@ -5,20 +5,26 @@ import { ConditionallyRender } from 'component/common/ConditionallyRender/Condit
 import { useStyles } from './FeatureLinkCell.styles';
 import { Highlighter } from 'component/common/Highlighter/Highlighter';
 import { useSearchHighlightContext } from 'component/common/Table/SearchHighlightContext/SearchHighlightContext';
-
+import classnames from 'classnames';
 interface IFeatureLinkCellProps {
     title?: string;
     to: string;
     subtitle?: string;
+    scrollAmount: number;
 }
 
 export const FeatureLinkCell: FC<IFeatureLinkCellProps> = ({
     title,
     to,
     subtitle,
+    scrollAmount,
 }) => {
     const { classes: styles } = useStyles();
     const search = useSearchHighlightContext();
+
+    const innerContainerClasses = classnames({
+        [styles.innerContainer]: scrollAmount > 200,
+    });
 
     return (
         <Link
@@ -27,33 +33,35 @@ export const FeatureLinkCell: FC<IFeatureLinkCellProps> = ({
             underline="hover"
             className={styles.wrapper}
         >
-            <div className={styles.container}>
-                <span
-                    data-loading
-                    className={styles.title}
-                    style={{
-                        WebkitLineClamp: Boolean(subtitle) ? 1 : 2,
-                        lineClamp: Boolean(subtitle) ? 1 : 2,
-                    }}
-                >
-                    <Highlighter search={search}>{title}</Highlighter>
-                </span>
-                <ConditionallyRender
-                    condition={Boolean(subtitle)}
-                    show={
-                        <>
-                            <Typography
-                                className={styles.description}
-                                component="span"
-                                data-loading
-                            >
-                                <Highlighter search={search}>
-                                    {subtitle}
-                                </Highlighter>
-                            </Typography>
-                        </>
-                    }
-                />
+            <div className={innerContainerClasses}>
+                <div className={styles.container}>
+                    <span
+                        data-loading
+                        className={styles.title}
+                        style={{
+                            WebkitLineClamp: Boolean(subtitle) ? 1 : 2,
+                            lineClamp: Boolean(subtitle) ? 1 : 2,
+                        }}
+                    >
+                        <Highlighter search={search}>{title}</Highlighter>
+                    </span>
+                    <ConditionallyRender
+                        condition={Boolean(subtitle)}
+                        show={
+                            <>
+                                <Typography
+                                    className={styles.description}
+                                    component="span"
+                                    data-loading
+                                >
+                                    <Highlighter search={search}>
+                                        {subtitle}
+                                    </Highlighter>
+                                </Typography>
+                            </>
+                        }
+                    />
+                </div>
             </div>
         </Link>
     );

--- a/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.styles.ts
+++ b/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.styles.ts
@@ -24,6 +24,9 @@ export const useStyles = makeStyles()(theme => ({
             },
         },
     },
+    tableRow: {
+        height: '75px',
+    },
     bodyClass: {
         overflowX: 'auto',
         padding: theme.spacing(4),

--- a/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
+++ b/src/component/project/Project/ProjectFeatureToggles/ProjectFeatureToggles.tsx
@@ -67,6 +67,7 @@ export const ProjectFeatureToggles = ({
         featureId: '',
         environmentName: '',
     });
+    const [scrollAmount, setScrollAmount] = useState(0);
     const projectId = useRequiredPathParam('projectId');
     const navigate = useNavigate();
     const { uiConfig } = useUiConfig();
@@ -75,6 +76,12 @@ export const ProjectFeatureToggles = ({
     );
     const { refetch } = useProject(projectId);
     const { setToastData, setToastApiError } = useToast();
+
+    const onScrollHandler = (ref: HTMLDivElement | null) => {
+        if (ref) {
+            setScrollAmount(ref.scrollLeft);
+        }
+    };
 
     const data = useMemo<ListItemType[]>(() => {
         if (loading) {
@@ -177,6 +184,7 @@ export const ProjectFeatureToggles = ({
                 accessor: 'name',
                 Cell: ({ value }: { value: string }) => (
                     <FeatureLinkCell
+                        scrollAmount={scrollAmount}
                         title={value}
                         to={`/projects/${projectId}/features/${value}`}
                     />
@@ -230,7 +238,7 @@ export const ProjectFeatureToggles = ({
                 disableSortBy: true,
             },
         ],
-        [projectId, environments, onToggle, loading]
+        [projectId, environments, onToggle, loading, scrollAmount]
     );
 
     const initialState = useMemo(
@@ -271,11 +279,13 @@ export const ProjectFeatureToggles = ({
         () => filters?.find(filterRow => filterRow?.id === 'name')?.value || '',
         [filters]
     );
+
     return (
         <PageContent
             isLoading={loading}
             className={styles.container}
             bodyClass={styles.bodyClass}
+            onScrollHandler={onScrollHandler}
             header={
                 <PageHeader
                     className={styles.title}

--- a/src/component/strategies/StrategiesList/__snapshots__/StrategiesList.test.tsx.snap
+++ b/src/component/strategies/StrategiesList/__snapshots__/StrategiesList.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`renders correctly 1`] = `
       </div>
       <div
         className="tss-54jt3w-bodyContainer"
+        onScroll={[Function]}
       >
         <ul
           className="MuiList-root MuiList-padding mui-h4y409-MuiList-root"

--- a/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
+++ b/src/component/tags/TagTypeList/__tests__/__snapshots__/TagTypeList.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`renders an empty list correctly 1`] = `
       </div>
       <div
         className="tss-54jt3w-bodyContainer"
+        onScroll={[Function]}
       >
         <ul
           className="MuiList-root MuiList-padding mui-h4y409-MuiList-root"

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
 import 'whatwg-fetch';
+import 'regenerator-runtime/runtime';
 
 process.env.TZ = 'UTC';


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

Adds sticky `<FeatureLinkCell />` on columns if scroll is present. 

Todo:
[] Re-rendering resets the column configuration. Should be solved when we add more robust persistent state to this configuration.

Discussion points: 
- This implementation only adds sticky fields on the actual cells. For the headers, because this logic is more encapsulated it will be more work to make the header sticky aswell. Is this enough for the current iteration?