### PR TITLE
Improve credential input attributes

### DIFF
--- a/src/component/user/HostedAuth/HostedAuth.tsx
+++ b/src/component/user/HostedAuth/HostedAuth.tsx
@@ -113,7 +113,7 @@ const HostedAuth: VFC<IHostedAuthProps> = ({ authDetails, redirect }) => {
                                 label="Username or email"
                                 name="username"
                                 id="username"
-                                type="string"
+                                type="text"
                                 onChange={evt => setUsername(evt.target.value)}
                                 value={username}
                                 error={Boolean(usernameError)}

--- a/src/component/user/HostedAuth/HostedAuth.tsx
+++ b/src/component/user/HostedAuth/HostedAuth.tsx
@@ -130,6 +130,7 @@ const HostedAuth: VFC<IHostedAuthProps> = ({ authDetails, redirect }) => {
                                 value={password}
                                 error={Boolean(passwordError)}
                                 helperText={passwordError}
+                                autoComplete="current-password"
                                 data-testid={LOGIN_PASSWORD_ID}
                             />
                             <Grid container>

--- a/src/component/user/PasswordAuth/PasswordAuth.tsx
+++ b/src/component/user/PasswordAuth/PasswordAuth.tsx
@@ -122,7 +122,7 @@ const PasswordAuth: VFC<IPasswordAuthProps> = ({ authDetails, redirect }) => {
                                 value={username}
                                 error={Boolean(usernameError)}
                                 helperText={usernameError}
-                                autoComplete="true"
+                                autoComplete="username"
                                 data-testid={LOGIN_EMAIL_ID}
                                 variant="outlined"
                                 size="small"
@@ -136,7 +136,7 @@ const PasswordAuth: VFC<IPasswordAuthProps> = ({ authDetails, redirect }) => {
                                 value={password}
                                 error={Boolean(passwordError)}
                                 helperText={passwordError}
-                                autoComplete="true"
+                                autoComplete="current-password"
                                 data-testid={LOGIN_PASSWORD_ID}
                             />
                             <Button

--- a/src/component/user/PasswordAuth/PasswordAuth.tsx
+++ b/src/component/user/PasswordAuth/PasswordAuth.tsx
@@ -117,7 +117,7 @@ const PasswordAuth: VFC<IPasswordAuthProps> = ({ authDetails, redirect }) => {
                                 label="Username or email"
                                 name="username"
                                 id="username"
-                                type="string"
+                                type="text"
                                 onChange={evt => setUsername(evt.target.value)}
                                 value={username}
                                 error={Boolean(usernameError)}

--- a/src/component/user/UserProfile/EditProfile/EditProfile.tsx
+++ b/src/component/user/UserProfile/EditProfile/EditProfile.tsx
@@ -115,7 +115,7 @@ const EditProfile = ({
                     label="Password"
                     name="password"
                     value={password}
-                    autoComplete="on"
+                    autoComplete="new-password"
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                         setPassword(e.target.value)
                     }
@@ -125,7 +125,7 @@ const EditProfile = ({
                     label="Confirm password"
                     name="confirmPassword"
                     value={confirmPassword}
-                    autoComplete="on"
+                    autoComplete="new-password"
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                         setConfirmPassword(e.target.value)
                     }

--- a/src/component/user/common/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/src/component/user/common/ResetPasswordForm/ResetPasswordForm.tsx
@@ -115,7 +115,7 @@ const ResetPasswordForm = ({ token, setLoading }: IResetPasswordProps) => {
                         setPassword(e.target.value)
                     }
                     onFocus={() => setShowPasswordChecker(true)}
-                    autoComplete="password"
+                    autoComplete="new-password"
                     data-loading
                 />
                 <PasswordField
@@ -124,7 +124,7 @@ const ResetPasswordForm = ({ token, setLoading }: IResetPasswordProps) => {
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                         setConfirmPassword(e.target.value)
                     }
-                    autoComplete="confirm-password"
+                    autoComplete="new-password"
                     data-loading
                 />
                 <ConditionallyRender


### PR DESCRIPTION
## About the changes
Several inputs for username/password had invalid values for some attributes, namely `type` and `autocomplete`. These changes ensure that password managers are able to work correctly for these fields.