### PR TITLE
feat/playground-second-iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,5 +137,11 @@
     "ignorePatterns": [
       "cypress"
     ]
+  },
+  "dependencies": {
+    "@codemirror/lang-json": "^6.0.0",
+    "@codemirror/state": "^6.1.0",
+    "@uiw/react-codemirror": "^4.11.4",
+    "codemirror": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,11 @@
     "vite-plugin-svgr": "2.2.0",
     "vite-tsconfig-paths": "3.5.0",
     "vitest": "0.16.0",
-    "whatwg-fetch": "^3.6.2"
+    "whatwg-fetch": "^3.6.2",
+    "@codemirror/lang-json": "^6.0.0",
+    "@codemirror/state": "^6.1.0",
+    "@uiw/react-codemirror": "^4.11.4",
+    "codemirror": "^6.0.1"
   },
   "jest": {
     "moduleNameMapper": {
@@ -137,11 +141,5 @@
     "ignorePatterns": [
       "cypress"
     ]
-  },
-  "dependencies": {
-    "@codemirror/lang-json": "^6.0.0",
-    "@codemirror/state": "^6.1.0",
-    "@uiw/react-codemirror": "^4.11.4",
-    "codemirror": "^6.0.1"
   }
 }

--- a/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.test.tsx
+++ b/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.test.tsx
@@ -1,4 +1,4 @@
-import { parseDateValue } from 'component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue';
+import { parseDateValue } from 'component/common/util';
 
 test(`Date component is able to parse midnight when it's 00`, () => {
     let f = parseDateValue('2022-03-15T12:27');

--- a/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
+++ b/src/component/common/ConstraintAccordion/ConstraintAccordionEdit/ConstraintAccordionEditBody/DateSingleValue/DateSingleValue.tsx
@@ -1,17 +1,12 @@
 import { ConstraintFormHeader } from '../ConstraintFormHeader/ConstraintFormHeader';
-import { format, isValid } from 'date-fns';
 import Input from 'component/common/Input/Input';
+import { parseDateValue, parseValidDate } from 'component/common/util';
 interface IDateSingleValueProps {
     setValue: (value: string) => void;
     value?: string;
     error: string;
     setError: React.Dispatch<React.SetStateAction<string>>;
 }
-
-export const parseDateValue = (value: string) => {
-    const date = new Date(value);
-    return format(date, 'yyyy-MM-dd') + 'T' + format(date, 'HH:mm');
-};
 
 export const DateSingleValue = ({
     setValue,
@@ -44,12 +39,4 @@ export const DateSingleValue = ({
             />
         </>
     );
-};
-
-const parseValidDate = (value: string): Date | undefined => {
-    const parsed = new Date(value);
-
-    if (isValid(parsed)) {
-        return parsed;
-    }
 };

--- a/src/component/common/GuidanceIndicator/GuidanceIndicator.tsx
+++ b/src/component/common/GuidanceIndicator/GuidanceIndicator.tsx
@@ -1,0 +1,40 @@
+import { styled, useTheme } from '@mui/material';
+import { FC } from 'react';
+
+const StyledIndicator = styled('div')(({ style, theme }) => ({
+    width: '25px',
+    height: '25px',
+    borderRadius: '50%',
+    color: theme.palette.text.tertiaryContrast,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontWeight: 'bold',
+    ...style,
+}));
+
+interface IGuidanceIndicatorProps {
+    style?: React.CSSProperties;
+    type?: guidanceIndicatorType;
+}
+
+type guidanceIndicatorType = 'primary' | 'secondary';
+
+export const GuidanceIndicator: FC<IGuidanceIndicatorProps> = ({
+    style,
+    children,
+    type,
+}) => {
+    const theme = useTheme();
+
+    const defaults = { backgroundColor: theme.palette.primary.main };
+    if (type === 'secondary') {
+        defaults.backgroundColor = theme.palette.tertiary.dark;
+    }
+
+    return (
+        <StyledIndicator style={{ ...defaults, ...style }}>
+            {children}
+        </StyledIndicator>
+    );
+};

--- a/src/component/common/Search/Search.tsx
+++ b/src/component/common/Search/Search.tsx
@@ -17,6 +17,7 @@ interface ISearchProps {
     hasFilters?: boolean;
     disabled?: boolean;
     getSearchContext?: () => IGetSearchContextOutput;
+    styles?: React.CSSProperties;
 }
 
 export const Search = ({
@@ -59,7 +60,7 @@ export const Search = ({
     const placeholder = `${customPlaceholder ?? 'Search'} (${hotkey})`;
 
     return (
-        <div className={styles.container}>
+        <div className={styles.container} styles={styles}>
             <div
                 className={classnames(
                     styles.search,

--- a/src/component/common/Search/Search.tsx
+++ b/src/component/common/Search/Search.tsx
@@ -17,7 +17,7 @@ interface ISearchProps {
     hasFilters?: boolean;
     disabled?: boolean;
     getSearchContext?: () => IGetSearchContextOutput;
-    styles?: React.CSSProperties;
+    containerStyles?: React.CSSProperties;
 }
 
 export const Search = ({
@@ -28,6 +28,7 @@ export const Search = ({
     hasFilters,
     disabled,
     getSearchContext,
+    containerStyles,
 }: ISearchProps) => {
     const ref = useRef<HTMLInputElement>();
     const { classes: styles } = useStyles();
@@ -60,7 +61,7 @@ export const Search = ({
     const placeholder = `${customPlaceholder ?? 'Search'} (${hotkey})`;
 
     return (
-        <div className={styles.container} styles={styles}>
+        <div className={styles.container} style={containerStyles}>
             <div
                 className={classnames(
                     styles.search,

--- a/src/component/common/Table/cells/TextCell/TextCell.styles.ts
+++ b/src/component/common/Table/cells/TextCell/TextCell.styles.ts
@@ -8,6 +8,7 @@ export const useStyles = makeStyles<{ lineClamp?: number }>()(
             overflow: lineClamp ? 'hidden' : 'auto',
             WebkitLineClamp: lineClamp ? lineClamp : 'none',
             WebkitBoxOrient: 'vertical',
+            wordBreak: 'break-all',
         },
     })
 );

--- a/src/component/common/util.ts
+++ b/src/component/common/util.ts
@@ -23,6 +23,10 @@ export const trim = (value: string): string => {
     }
 };
 
+export const calculateVariantWeight = (weight: number) => {
+    return weight / 10.0;
+};
+
 export function updateWeight(variants: IFeatureVariant[], totalWeight: number) {
     if (variants.length === 0) {
         return [];

--- a/src/component/common/util.ts
+++ b/src/component/common/util.ts
@@ -2,6 +2,7 @@ import { weightTypes } from '../feature/FeatureView/FeatureVariants/FeatureVaria
 import { IFlags } from 'interfaces/uiConfig';
 import { IRoute } from 'interfaces/route';
 import { IFeatureVariant } from 'interfaces/featureToggle';
+import { format, isValid } from 'date-fns';
 
 export const filterByFlags = (flags: IFlags) => (r: IRoute) => {
     if (!r.flag) {
@@ -20,6 +21,19 @@ export const trim = (value: string): string => {
         return value.trim();
     } else {
         return value;
+    }
+};
+
+export const parseDateValue = (value: string) => {
+    const date = new Date(value);
+    return format(date, 'yyyy-MM-dd') + 'T' + format(date, 'HH:mm');
+};
+
+export const parseValidDate = (value: string): Date | undefined => {
+    const parsed = new Date(value);
+
+    if (isValid(parsed)) {
+        return parsed;
     }
 };
 

--- a/src/component/feature/FeatureView/FeatureVariants/FeatureVariantsList/FeatureVariantsList.tsx
+++ b/src/component/feature/FeatureView/FeatureVariants/FeatureVariantsList/FeatureVariantsList.tsx
@@ -9,7 +9,6 @@ import {
     useMediaQuery,
 } from '@mui/material';
 import { AddVariant } from './AddFeatureVariant/AddFeatureVariant';
-
 import { useContext, useEffect, useState, useMemo, useCallback } from 'react';
 import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 import AccessContext from 'contexts/AccessContext';
@@ -20,7 +19,7 @@ import GeneralSelect from 'component/common/GeneralSelect/GeneralSelect';
 import { IFeatureVariant } from 'interfaces/featureToggle';
 import useFeatureApi from 'hooks/api/actions/useFeatureApi/useFeatureApi';
 import useToast from 'hooks/useToast';
-import { updateWeight } from 'component/common/util';
+import { calculateVariantWeight, updateWeight } from 'component/common/util';
 import cloneDeep from 'lodash.clonedeep';
 import useDeleteVariantMarkup from './useDeleteVariantMarkup';
 import PermissionButton from 'component/common/PermissionButton/PermissionButton';
@@ -141,7 +140,7 @@ export const FeatureVariantsList = () => {
                 }: any) => {
                     return (
                         <TextCell data-testid={`VARIANT_WEIGHT_${name}`}>
-                            {weight / 10.0} %
+                            {calculateVariantWeight(weight)} %
                         </TextCell>
                     );
                 },

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -1,6 +1,6 @@
 import { FormEventHandler, useEffect, useState, VFC } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Box, Paper, useMediaQuery, useTheme, IconButton } from '@mui/material';
+import { Box, Paper, useMediaQuery, useTheme } from '@mui/material';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import useToast from 'hooks/useToast';
@@ -11,9 +11,12 @@ import { usePlaygroundApi } from 'hooks/api/actions/usePlayground/usePlayground'
 import { PlaygroundResponseSchema } from 'hooks/api/actions/usePlayground/playground.model';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import { PlaygroundForm } from './PlaygroundForm/PlaygroundForm';
-import { resolveDefaultEnvironment, resolveProjects } from './playground.utils';
+import {
+    resolveDefaultEnvironment,
+    resolveProjects,
+    resolveResultsWidth,
+} from './playground.utils';
 import { PlaygroundGuidance } from './PlaygroundGuidance/PlaygroundGuidance';
-import { Help } from '@mui/icons-material';
 import { PlaygroundGuidancePopper } from './PlaygroundGuidancePopper/PlaygroundGuidancePopper';
 
 export const Playground: VFC<{}> = () => {
@@ -134,20 +137,8 @@ export const Playground: VFC<{}> = () => {
         setSearchParams(searchParams);
     };
 
-    const resolveResultsWidth = () => {
-        if (matches) {
-            return '100%';
-        }
-
-        if (results && !matches) {
-            return '65%';
-        }
-
-        return '50%';
-    };
-
     const formWidth = results && !matches ? '35%' : 'auto';
-    const resultsWidth = resolveResultsWidth();
+    const resultsWidth = resolveResultsWidth(matches, results);
 
     return (
         <PageContent

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -134,14 +134,6 @@ export const Playground: VFC<{}> = () => {
         setSearchParams(searchParams);
     };
 
-    const resolveFormWidth = () => {
-        if (results && !matches) {
-            return '35%';
-        }
-
-        return 'auto';
-    };
-
     const resolveResultsWidth = () => {
         if (matches) {
             return '100%';
@@ -154,7 +146,7 @@ export const Playground: VFC<{}> = () => {
         return '50%';
     };
 
-    const formWidth = resolveFormWidth();
+    const formWidth = results && !matches ? '35%' : 'auto';
     const resultsWidth = resolveResultsWidth();
 
     return (

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -12,6 +12,7 @@ import { PlaygroundResponseSchema } from 'hooks/api/actions/usePlayground/playgr
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import { PlaygroundForm } from './PlaygroundForm/PlaygroundForm';
 import { resolveDefaultEnvironment, resolveProjects } from './playground.utils';
+import { PlaygroundGuidance } from './PlaygroundGuidance/PlaygroundGuidance';
 
 export const Playground: VFC<{}> = () => {
     const { environments } = useEnvironments();
@@ -149,6 +150,7 @@ export const Playground: VFC<{}> = () => {
                         m: 4,
                         background: theme.palette.grey[200],
                         transition: 'width 0.4s ease',
+                        minWidth: '500px',
                         width: formWidth,
                     }}
                 >
@@ -165,7 +167,11 @@ export const Playground: VFC<{}> = () => {
                 </Paper>
 
                 <Box
-                    sx={{ width: resultsWidth, transition: 'width 0.4s ease' }}
+                    sx={theme => ({
+                        width: resultsWidth,
+                        transition: 'width 0.4s ease',
+                        padding: theme.spacing(4, 2),
+                    })}
                 >
                     <ConditionallyRender
                         condition={Boolean(results)}
@@ -175,6 +181,7 @@ export const Playground: VFC<{}> = () => {
                                 features={results?.features}
                             />
                         }
+                        elseShow={<PlaygroundGuidance />}
                     />
                 </Box>
             </Box>

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -1,6 +1,6 @@
 import { FormEventHandler, useEffect, useState, VFC } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Box, Paper, useTheme } from '@mui/material';
+import { Box, Paper, useMediaQuery, useTheme } from '@mui/material';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import useToast from 'hooks/useToast';
@@ -17,6 +17,7 @@ import { PlaygroundGuidance } from './PlaygroundGuidance/PlaygroundGuidance';
 export const Playground: VFC<{}> = () => {
     const { environments } = useEnvironments();
     const theme = useTheme();
+    const matches = useMediaQuery(theme.breakpoints.down('lg'));
 
     const [environment, setEnvironment] = useState<string>('');
     const [projects, setProjects] = useState<string[]>([]);
@@ -131,8 +132,34 @@ export const Playground: VFC<{}> = () => {
         setSearchParams(searchParams);
     };
 
-    const formWidth = results ? '40%' : '50%';
-    const resultsWidth = results ? '60%' : '50%';
+    const resolveFormWidth = () => {
+        if (results && !matches) {
+            return '35%';
+        }
+
+        return 'auto';
+    };
+
+    const resolveResultsWidth = () => {
+        if (matches) {
+            return '100%';
+        }
+
+        if (results && !matches) {
+            return '65%';
+        }
+
+        return '50%';
+    };
+
+    const resolveLayout = () => {
+        if (!matches) {
+            return { display: 'flex' };
+        }
+        return { display: 'flex', flexDirection: 'column' };
+    };
+    const formWidth = resolveFormWidth();
+    const resultsWidth = resolveResultsWidth();
 
     return (
         <PageContent
@@ -140,21 +167,21 @@ export const Playground: VFC<{}> = () => {
             disableLoading
             bodyClass={'no-padding'}
         >
-            <Box sx={{ display: 'flex' }}>
-                <Box>
+            <Box sx={resolveLayout()}>
+                <Box sx={{ background: theme.palette.grey[200] }}>
                     <Paper
                         elevation={0}
                         sx={{
                             px: 4,
                             py: 3,
                             mb: 4,
-                            m: 4,
+                            mt: 2,
                             background: theme.palette.grey[200],
                             transition: 'width 0.4s ease',
-                            minWidth: '500px',
+                            minWidth: matches ? 'auto' : '500px',
                             width: formWidth,
                             position: 'sticky',
-                            top: '10px',
+                            top: 0,
                         }}
                     >
                         <PlaygroundForm

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -19,6 +19,8 @@ import { ContextBanner } from './PlaygroundResultsTable/ContextBanner/ContextBan
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import usePlaygroundApi from 'hooks/api/actions/usePlayground/usePlayground';
 import { PlaygroundResponseSchema } from 'hooks/api/actions/usePlayground/playground.model';
+import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
+import { IEnvironment } from 'interfaces/environments';
 
 const resolveProjects = (projects: string[] | string): string[] | string => {
     return !projects ||
@@ -28,8 +30,25 @@ const resolveProjects = (projects: string[] | string): string[] | string => {
         : projects;
 };
 
+const resolveDefaultEnvironment = (environmentOptions: IEnvironment[]) => {
+    const options = getEnvironmentOptions(environmentOptions);
+    if (options.length > 0) {
+        return options[0];
+    }
+    return '';
+};
+
+const getEnvironmentOptions = (environments: IEnvironment[]) => {
+    return environments
+        .filter(({ enabled }) => Boolean(enabled))
+        .sort((a, b) => a.sortOrder - b.sortOrder)
+        .map(({ name }) => name);
+};
+
 export const Playground: VFC<{}> = () => {
     const theme = useTheme();
+    const { environments } = useEnvironments();
+
     const [environment, setEnvironment] = useState<string>('');
     const [projects, setProjects] = useState<string[]>([]);
     const [context, setContext] = useState<string>();
@@ -39,6 +58,10 @@ export const Playground: VFC<{}> = () => {
     const { setToastData } = useToast();
     const [searchParams, setSearchParams] = useSearchParams();
     const { evaluatePlayground, loading } = usePlaygroundApi();
+
+    useEffect(() => {
+        setEnvironment(resolveDefaultEnvironment(environments));
+    }, [environments]);
 
     useEffect(() => {
         // Load initial values from URL
@@ -168,6 +191,7 @@ export const Playground: VFC<{}> = () => {
                         projects={projects}
                         setEnvironment={setEnvironment}
                         setProjects={setProjects}
+                        environmentOptions={getEnvironmentOptions(environments)}
                     />
                     <Divider
                         variant="fullWidth"

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -1,55 +1,21 @@
-import { FormEventHandler, useEffect, useState, useCallback, VFC } from 'react';
+import { FormEventHandler, useEffect, useState, VFC } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import {
-    Box,
-    Button,
-    Divider,
-    Paper,
-    Typography,
-    useTheme,
-} from '@mui/material';
+import { Box, Paper, useTheme } from '@mui/material';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
-import { PlaygroundConnectionFieldset } from './PlaygroundConnectionFieldset/PlaygroundConnectionFieldset';
-import { PlaygroundCodeFieldset } from './PlaygroundCodeFieldset/PlaygroundCodeFieldset';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { PlaygroundResultsTable } from './PlaygroundResultsTable/PlaygroundResultsTable';
-import { ContextBanner } from './PlaygroundResultsTable/ContextBanner/ContextBanner';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import usePlaygroundApi from 'hooks/api/actions/usePlayground/usePlayground';
 import { PlaygroundResponseSchema } from 'hooks/api/actions/usePlayground/playground.model';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
-import { IEnvironment } from 'interfaces/environments';
-import CodeMirror from '@uiw/react-codemirror';
-import { json } from '@codemirror/lang-json';
-
-const resolveProjects = (projects: string[] | string): string[] | string => {
-    return !projects ||
-        projects.length === 0 ||
-        (projects.length === 1 && projects[0] === '*')
-        ? '*'
-        : projects;
-};
-
-const resolveDefaultEnvironment = (environmentOptions: IEnvironment[]) => {
-    const options = getEnvironmentOptions(environmentOptions);
-    if (options.length > 0) {
-        return options[0];
-    }
-    return '';
-};
-
-const getEnvironmentOptions = (environments: IEnvironment[]) => {
-    return environments
-        .filter(({ enabled }) => Boolean(enabled))
-        .sort((a, b) => a.sortOrder - b.sortOrder)
-        .map(({ name }) => name);
-};
+import { PlaygroundForm } from './PlaygroundForm/PlaygroundForm';
+import { resolveDefaultEnvironment, resolveProjects } from './playground.utils';
 
 export const Playground: VFC<{}> = () => {
-    const theme = useTheme();
     const { environments } = useEnvironments();
+    const theme = useTheme();
 
     const [environment, setEnvironment] = useState<string>('');
     const [projects, setProjects] = useState<string[]>([]);
@@ -164,9 +130,8 @@ export const Playground: VFC<{}> = () => {
         setSearchParams(searchParams);
     };
 
-    const onCodeFieldChange = useCallback(value => {
-        setContext(value);
-    }, []);
+    const formWidth = results ? '40%' : '50%';
+    const resultsWidth = results ? '60%' : '50%';
 
     return (
         <PageContent
@@ -174,89 +139,45 @@ export const Playground: VFC<{}> = () => {
             disableLoading
             bodyClass={'no-padding'}
         >
-            <Paper
-                elevation={0}
-                sx={{
-                    px: 4,
-                    py: 3,
-                    mb: 4,
-                    m: 4,
-                    background: theme.palette.grey[200],
-                }}
-            >
-                <Box component="form" onSubmit={onSubmit}>
-                    <Typography
-                        sx={{
-                            mb: 3,
-                        }}
-                    >
-                        Configure playground
-                    </Typography>
-                    <PlaygroundConnectionFieldset
-                        environment={environment}
+            <Box sx={{ display: 'flex' }}>
+                <Paper
+                    elevation={0}
+                    sx={{
+                        px: 4,
+                        py: 3,
+                        mb: 4,
+                        m: 4,
+                        background: theme.palette.grey[200],
+                        transition: 'width 0.4s ease',
+                        width: formWidth,
+                    }}
+                >
+                    <PlaygroundForm
+                        onSubmit={onSubmit}
+                        context={context}
+                        setContext={setContext}
+                        environments={environments}
                         projects={projects}
-                        setEnvironment={setEnvironment}
+                        environment={environment}
                         setProjects={setProjects}
-                        environmentOptions={getEnvironmentOptions(environments)}
+                        setEnvironment={setEnvironment}
                     />
-                    <Divider
-                        variant="fullWidth"
-                        sx={{
-                            mb: 2,
-                            borderColor: theme.palette.dividerAlternative,
-                            borderStyle: 'dashed',
-                        }}
-                    />
-                    <PlaygroundCodeFieldset
-                        value={context}
-                        setValue={setContext}
-                    />
-                    <CodeMirror
-                        value={context}
-                        height="200px"
-                        extensions={[json()]}
-                        onChange={onCodeFieldChange}
-                    />
-                    <Divider
-                        variant="fullWidth"
-                        sx={{
-                            mt: 3,
-                            mb: 2,
-                            borderColor: theme.palette.dividerAlternative,
-                        }}
-                    />
-                    <Button variant="contained" size="large" type="submit">
-                        Try configuration
-                    </Button>
-                </Box>
-            </Paper>
-            <ConditionallyRender
-                condition={Boolean(results)}
-                show={
-                    <>
-                        <Divider />
-                        <ContextBanner
-                            environment={
-                                (results as PlaygroundResponseSchema)?.input
-                                    ?.environment
-                            }
-                            projects={
-                                (results as PlaygroundResponseSchema)?.input
-                                    ?.projects
-                            }
-                            context={
-                                (results as PlaygroundResponseSchema)?.input
-                                    ?.context
-                            }
-                        />
-                    </>
-                }
-            />
+                </Paper>
 
-            <PlaygroundResultsTable
-                loading={loading}
-                features={results?.features}
-            />
+                <Box
+                    sx={{ width: resultsWidth, transition: 'width 0.4s ease' }}
+                >
+                    <ConditionallyRender
+                        condition={Boolean(results)}
+                        show={
+                            <PlaygroundResultsTable
+                                loading={loading}
+                                features={results?.features}
+                            />
+                        }
+                    />
+                </Box>
+            </Box>
         </PageContent>
     );
 };

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -1,18 +1,20 @@
 import { FormEventHandler, useEffect, useState, VFC } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Box, Paper, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Paper, useMediaQuery, useTheme, IconButton } from '@mui/material';
 import { PageContent } from 'component/common/PageContent/PageContent';
 import { PageHeader } from 'component/common/PageHeader/PageHeader';
 import useToast from 'hooks/useToast';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import { PlaygroundResultsTable } from './PlaygroundResultsTable/PlaygroundResultsTable';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import usePlaygroundApi from 'hooks/api/actions/usePlayground/usePlayground';
+import { usePlaygroundApi } from 'hooks/api/actions/usePlayground/usePlayground';
 import { PlaygroundResponseSchema } from 'hooks/api/actions/usePlayground/playground.model';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import { PlaygroundForm } from './PlaygroundForm/PlaygroundForm';
 import { resolveDefaultEnvironment, resolveProjects } from './playground.utils';
 import { PlaygroundGuidance } from './PlaygroundGuidance/PlaygroundGuidance';
+import { Help } from '@mui/icons-material';
+import { PlaygroundGuidancePopper } from './PlaygroundGuidancePopper/PlaygroundGuidancePopper';
 
 export const Playground: VFC<{}> = () => {
     const { environments } = useEnvironments();
@@ -157,7 +159,12 @@ export const Playground: VFC<{}> = () => {
 
     return (
         <PageContent
-            header={<PageHeader title="Unleash playground" />}
+            header={
+                <PageHeader
+                    title="Unleash playground"
+                    actions={<PlaygroundGuidancePopper />}
+                />
+            }
             disableLoading
             bodyClass={'no-padding'}
         >
@@ -167,7 +174,12 @@ export const Playground: VFC<{}> = () => {
                     flexDirection: !matches ? 'row' : 'column',
                 }}
             >
-                <Box sx={{ background: theme.palette.grey[200] }}>
+                <Box
+                    sx={{
+                        background: theme.palette.grey[200],
+                        borderBottomLeftRadius: theme.shape.borderRadiusMedium,
+                    }}
+                >
                     <Paper
                         elevation={0}
                         sx={{

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -141,31 +141,34 @@ export const Playground: VFC<{}> = () => {
             bodyClass={'no-padding'}
         >
             <Box sx={{ display: 'flex' }}>
-                <Paper
-                    elevation={0}
-                    sx={{
-                        px: 4,
-                        py: 3,
-                        mb: 4,
-                        m: 4,
-                        background: theme.palette.grey[200],
-                        transition: 'width 0.4s ease',
-                        minWidth: '500px',
-                        width: formWidth,
-                    }}
-                >
-                    <PlaygroundForm
-                        onSubmit={onSubmit}
-                        context={context}
-                        setContext={setContext}
-                        environments={environments}
-                        projects={projects}
-                        environment={environment}
-                        setProjects={setProjects}
-                        setEnvironment={setEnvironment}
-                    />
-                </Paper>
-
+                <Box>
+                    <Paper
+                        elevation={0}
+                        sx={{
+                            px: 4,
+                            py: 3,
+                            mb: 4,
+                            m: 4,
+                            background: theme.palette.grey[200],
+                            transition: 'width 0.4s ease',
+                            minWidth: '500px',
+                            width: formWidth,
+                            position: 'sticky',
+                            top: '10px',
+                        }}
+                    >
+                        <PlaygroundForm
+                            onSubmit={onSubmit}
+                            context={context}
+                            setContext={setContext}
+                            environments={environments}
+                            projects={projects}
+                            environment={environment}
+                            setProjects={setProjects}
+                            setEnvironment={setEnvironment}
+                        />
+                    </Paper>
+                </Box>
                 <Box
                     sx={theme => ({
                         width: resultsWidth,

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -152,12 +152,6 @@ export const Playground: VFC<{}> = () => {
         return '50%';
     };
 
-    const resolveLayout = () => {
-        if (!matches) {
-            return { display: 'flex' };
-        }
-        return { display: 'flex', flexDirection: 'column' };
-    };
     const formWidth = resolveFormWidth();
     const resultsWidth = resolveResultsWidth();
 
@@ -167,7 +161,12 @@ export const Playground: VFC<{}> = () => {
             disableLoading
             bodyClass={'no-padding'}
         >
-            <Box sx={resolveLayout()}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: !matches ? 'row' : 'column',
+                }}
+            >
                 <Box sx={{ background: theme.palette.grey[200] }}>
                     <Paper
                         elevation={0}

--- a/src/component/playground/Playground/Playground.tsx
+++ b/src/component/playground/Playground/Playground.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler, useEffect, useState, VFC } from 'react';
+import { FormEventHandler, useEffect, useState, useCallback, VFC } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
     Box,
@@ -21,6 +21,8 @@ import usePlaygroundApi from 'hooks/api/actions/usePlayground/usePlayground';
 import { PlaygroundResponseSchema } from 'hooks/api/actions/usePlayground/playground.model';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import { IEnvironment } from 'interfaces/environments';
+import CodeMirror from '@uiw/react-codemirror';
+import { json } from '@codemirror/lang-json';
 
 const resolveProjects = (projects: string[] | string): string[] | string => {
     return !projects ||
@@ -162,6 +164,10 @@ export const Playground: VFC<{}> = () => {
         setSearchParams(searchParams);
     };
 
+    const onCodeFieldChange = useCallback(value => {
+        setContext(value);
+    }, []);
+
     return (
         <PageContent
             header={<PageHeader title="Unleash playground" />}
@@ -204,6 +210,12 @@ export const Playground: VFC<{}> = () => {
                     <PlaygroundCodeFieldset
                         value={context}
                         setValue={setContext}
+                    />
+                    <CodeMirror
+                        value={context}
+                        height="200px"
+                        extensions={[json()]}
+                        onChange={onCodeFieldChange}
                     />
                     <Divider
                         variant="fullWidth"

--- a/src/component/playground/Playground/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/src/component/playground/Playground/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -143,7 +143,7 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
                     } `}
                 </Button>
             </Box>
-            <TextField
+            {/* <TextField
                 error={Boolean(error)}
                 helperText={error}
                 autoCorrect="off"
@@ -165,7 +165,7 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
                 InputProps={{ minRows: 5 }}
                 value={value}
                 onChange={event => setValue(event.target.value)}
-            />
+            /> */}
         </Box>
     );
 };

--- a/src/component/playground/Playground/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/src/component/playground/Playground/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -96,30 +96,8 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
             >
                 Unleash context
             </Typography>
-            <TextField
-                error={Boolean(error)}
-                helperText={error}
-                autoCorrect="off"
-                spellCheck={false}
-                multiline
-                label="JSON"
-                placeholder={JSON.stringify(
-                    {
-                        currentTime: '2022-07-04T14:13:03.929Z',
-                        appName: 'playground',
-                        userId: 'test',
-                        remoteAddress: '127.0.0.1',
-                    },
-                    null,
-                    2
-                )}
-                fullWidth
-                InputLabelProps={{ shrink: true }}
-                InputProps={{ minRows: 5 }}
-                value={value}
-                onChange={event => setValue(event.target.value)}
-            />
-            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mt: 2 }}>
+
+            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
                 <FormControl>
                     <InputLabel id="context-field-label" size="small">
                         Context field
@@ -165,6 +143,29 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
                     } `}
                 </Button>
             </Box>
+            <TextField
+                error={Boolean(error)}
+                helperText={error}
+                autoCorrect="off"
+                spellCheck={false}
+                multiline
+                label="JSON"
+                placeholder={JSON.stringify(
+                    {
+                        currentTime: '2022-07-04T14:13:03.929Z',
+                        appName: 'playground',
+                        userId: 'test',
+                        remoteAddress: '127.0.0.1',
+                    },
+                    null,
+                    2
+                )}
+                fullWidth
+                InputLabelProps={{ shrink: true }}
+                InputProps={{ minRows: 5 }}
+                value={value}
+                onChange={event => setValue(event.target.value)}
+            />
         </Box>
     );
 };

--- a/src/component/playground/Playground/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
+++ b/src/component/playground/Playground/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
@@ -14,6 +14,7 @@ interface IPlaygroundConnectionFieldsetProps {
     projects: string[];
     setProjects: (projects: string[]) => void;
     setEnvironment: (environment: string) => void;
+    environmentOptions: string[];
 }
 
 interface IOption {
@@ -25,13 +26,14 @@ const allOption: IOption = { label: 'ALL', id: '*' };
 
 export const PlaygroundConnectionFieldset: VFC<
     IPlaygroundConnectionFieldsetProps
-> = ({ environment, projects, setProjects, setEnvironment }) => {
+> = ({
+    environment,
+    projects,
+    setProjects,
+    setEnvironment,
+    environmentOptions,
+}) => {
     const theme = useTheme();
-    const { environments } = useEnvironments();
-    const environmentOptions = environments
-        .filter(({ enabled }) => Boolean(enabled))
-        .sort((a, b) => a.sortOrder - b.sortOrder)
-        .map(({ name }) => name);
 
     const { projects: availableProjects = [] } = useProjects();
     const projectsOptions = [

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -26,26 +26,11 @@ import { formatUnknownError } from 'utils/formatUnknownError';
 import useToast from 'hooks/useToast';
 import { PlaygroundEditor } from './PlaygroundEditor/PlaygroundEditor';
 import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
-import { format, isValid } from 'date-fns';
-import Input from 'component/common/Input/Input';
-
+import { parseDateValue, parseValidDate } from 'component/common/util';
 interface IPlaygroundCodeFieldsetProps {
     context: string | undefined;
     setContext: Dispatch<SetStateAction<string | undefined>>;
 }
-
-export const parseDateValue = (value: string) => {
-    const date = new Date(value);
-    return format(date, 'yyyy-MM-dd') + 'T' + format(date, 'HH:mm');
-};
-
-const parseValidDate = (value: string): Date | undefined => {
-    const parsed = new Date(value);
-
-    if (isValid(parsed)) {
-        return parsed;
-    }
-};
 
 export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
     context,

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -143,7 +143,7 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
                     variant="outlined"
                     disabled={!contextField || Boolean(error)}
                     onClick={onAddField}
-                    sx={{ marginLeft: 'auto', width: '95px' }}
+                    sx={{ width: '95px' }}
                 >
                     {`${!fieldExist ? 'Add' : 'Replace'} `}
                 </Button>

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundCodeFieldset.tsx
@@ -16,20 +16,25 @@ import {
     TextField,
     Typography,
     useTheme,
+    Alert,
 } from '@mui/material';
+
 import { debounce } from 'debounce';
 import useUnleashContext from 'hooks/api/getters/useUnleashContext/useUnleashContext';
 import { formatUnknownError } from 'utils/formatUnknownError';
 import useToast from 'hooks/useToast';
+import { PlaygroundEditor } from './PlaygroundEditor/PlaygroundEditor';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
 
 interface IPlaygroundCodeFieldsetProps {
-    value: string | undefined;
-    setValue: Dispatch<SetStateAction<string | undefined>>;
+    context: string | undefined;
+    setContext: Dispatch<SetStateAction<string | undefined>>;
 }
 
 export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
-    value,
-    setValue,
+    context,
+    setContext,
 }) => {
     const theme = useTheme();
     const { setToastData } = useToast();
@@ -62,13 +67,13 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
     );
 
     useEffect(() => {
-        debounceJsonParsing(value);
-    }, [debounceJsonParsing, value]);
+        debounceJsonParsing(context);
+    }, [debounceJsonParsing, context]);
 
     const onAddField = () => {
         try {
-            const currentValue = JSON.parse(value || '{}');
-            setValue(
+            const currentValue = JSON.parse(context || '{}');
+            setContext(
                 JSON.stringify(
                     {
                         ...currentValue,
@@ -89,13 +94,16 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
 
     return (
         <Box>
-            <Typography
-                variant="body2"
-                sx={{ mb: 2 }}
-                color={theme.palette.text.secondary}
-            >
-                Unleash context
-            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                <GuidanceIndicator type="secondary">2</GuidanceIndicator>
+                <Typography
+                    variant="body2"
+                    color={theme.palette.text.secondary}
+                    sx={{ ml: 1 }}
+                >
+                    Unleash context
+                </Typography>
+            </Box>
 
             <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
                 <FormControl>
@@ -112,7 +120,7 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
                         }
                         variant="outlined"
                         size="small"
-                        sx={{ width: 300, maxWidth: '100%' }}
+                        sx={{ width: 200, maxWidth: '100%' }}
                     >
                         {contextOptions.map(option => (
                             <MenuItem key={option} value={option}>
@@ -124,7 +132,7 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
                 <TextField
                     label="Value"
                     id="context-value"
-                    sx={{ width: 300, maxWidth: '100%' }}
+                    sx={{ width: 200, maxWidth: '100%' }}
                     size="small"
                     value={contextValue}
                     onChange={event =>
@@ -135,37 +143,17 @@ export const PlaygroundCodeFieldset: VFC<IPlaygroundCodeFieldsetProps> = ({
                     variant="outlined"
                     disabled={!contextField || Boolean(error)}
                     onClick={onAddField}
+                    sx={{ marginLeft: 'auto', width: '95px' }}
                 >
-                    {`${
-                        !fieldExist
-                            ? 'Add context field'
-                            : 'Replace context field value'
-                    } `}
+                    {`${!fieldExist ? 'Add' : 'Replace'} `}
                 </Button>
             </Box>
-            {/* <TextField
-                error={Boolean(error)}
-                helperText={error}
-                autoCorrect="off"
-                spellCheck={false}
-                multiline
-                label="JSON"
-                placeholder={JSON.stringify(
-                    {
-                        currentTime: '2022-07-04T14:13:03.929Z',
-                        appName: 'playground',
-                        userId: 'test',
-                        remoteAddress: '127.0.0.1',
-                    },
-                    null,
-                    2
-                )}
-                fullWidth
-                InputLabelProps={{ shrink: true }}
-                InputProps={{ minRows: 5 }}
-                value={value}
-                onChange={event => setValue(event.target.value)}
-            /> */}
+
+            <PlaygroundEditor
+                context={context}
+                setContext={setContext}
+                error={error}
+            />
         </Box>
     );
 };

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -1,0 +1,119 @@
+import CodeMirror from '@uiw/react-codemirror';
+import { json } from '@codemirror/lang-json';
+import { Dispatch, SetStateAction, VFC, useCallback } from 'react';
+import { styled, Alert, useTheme, Box } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import Check from '@mui/icons-material/Check';
+import { Error } from '@mui/icons-material';
+
+interface IPlaygroundEditorProps {
+    context: string | undefined;
+    setContext: Dispatch<SetStateAction<string | undefined>>;
+    error: string | undefined;
+}
+
+const StyledEditorHeader = styled('aside')(({ theme }) => ({
+    height: '50px',
+    backgroundColor: theme.palette.grey[100],
+    borderTopRightRadius: '5px',
+    borderTopLeftRadius: '5px',
+    padding: theme.spacing(1, 2),
+    color: theme.palette.text.primary,
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+}));
+
+const StyledEditorStatusContainer = styled('div')(({ theme, style }) => ({
+    width: '28px',
+    height: '28px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: `background-color 0.5s ease-in-out`,
+    borderRadius: '50%',
+    opacity: 0.8,
+    ...style,
+}));
+
+const StyledErrorSpan = styled('div')(({ theme }) => ({
+    fontSize: '0.9rem',
+    color: theme.palette.error.main,
+    marginRight: theme.spacing(1),
+}));
+
+const EditorStatusOk = () => {
+    const theme = useTheme();
+    return (
+        <StyledEditorStatusContainer
+            style={{
+                color: '#fff',
+                backgroundColor: theme.palette.success.main,
+            }}
+        >
+            <Check sx={{ width: '20px', height: '20px' }} />
+        </StyledEditorStatusContainer>
+    );
+};
+
+const EditorStatusError = () => {
+    const theme = useTheme();
+
+    return (
+        <StyledEditorStatusContainer
+            style={{
+                color: '#fff',
+                backgroundColor: theme.palette.error.main,
+            }}
+        >
+            <Error />
+        </StyledEditorStatusContainer>
+    );
+};
+
+export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
+    context,
+    setContext,
+    error,
+}) => {
+    const onCodeFieldChange = useCallback(
+        context => {
+            setContext(context);
+        },
+        [setContext]
+    );
+
+    return (
+        <div>
+            <StyledEditorHeader>
+                Json
+                <ConditionallyRender
+                    condition={Boolean(error)}
+                    show={
+                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                            <StyledErrorSpan>{error}</StyledErrorSpan>
+                            <EditorStatusError />
+                        </Box>
+                    }
+                    elseShow={<EditorStatusOk />}
+                />
+            </StyledEditorHeader>
+            <CodeMirror
+                value={context}
+                height="200px"
+                extensions={[json()]}
+                onChange={onCodeFieldChange}
+                placeholder={JSON.stringify(
+                    {
+                        currentTime: '2022-07-04T14:13:03.929Z',
+                        appName: 'playground',
+                        userId: 'test',
+                        remoteAddress: '127.0.0.1',
+                    },
+                    null,
+                    2
+                )}
+            />
+        </div>
+    );
+};

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -15,8 +15,8 @@ interface IPlaygroundEditorProps {
 const StyledEditorHeader = styled('aside')(({ theme }) => ({
     height: '50px',
     backgroundColor: theme.palette.grey[100],
-    borderTopRightRadius: '5px',
-    borderTopLeftRadius: '5px',
+    borderTopRightRadius: theme.shape.borderRadiusMedium,
+    borderTopLeftRadius: theme.shape.borderRadiusMedium,
     padding: theme.spacing(1, 2),
     color: theme.palette.text.primary,
     display: 'flex',

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -114,8 +114,8 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
                 style={{
                     border: `1px solid ${theme.palette.lightBorder}`,
                     borderTop: 'none',
-                    borderBottomLeftRadius: '3px',
-                    borderBottomRightRadius: '3px',
+                    borderBottomLeftRadius: theme.shape.borderRadiusMedium,
+                    borderBottomRightRadius: theme.shape.borderRadiusMedium,
                 }}
                 placeholder={JSON.stringify(
                     {

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -1,7 +1,7 @@
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
 import { Dispatch, SetStateAction, VFC, useCallback } from 'react';
-import { styled, Alert, useTheme, Box } from '@mui/material';
+import { styled, useTheme, Box } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import Check from '@mui/icons-material/Check';
 import { Error } from '@mui/icons-material';
@@ -22,6 +22,8 @@ const StyledEditorHeader = styled('aside')(({ theme }) => ({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
+    border: `1px solid ${theme.palette.lightBorder}`,
+    borderBottom: 'none',
 }));
 
 const StyledEditorStatusContainer = styled('div')(({ theme, style }) => ({
@@ -76,6 +78,7 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
     setContext,
     error,
 }) => {
+    const theme = useTheme();
     const onCodeFieldChange = useCallback(
         context => {
             setContext(context);
@@ -90,7 +93,12 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
                 <ConditionallyRender
                     condition={Boolean(error)}
                     show={
-                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        <Box
+                            sx={theme => ({
+                                display: 'flex',
+                                alignItems: 'center',
+                            })}
+                        >
                             <StyledErrorSpan>{error}</StyledErrorSpan>
                             <EditorStatusError />
                         </Box>
@@ -103,6 +111,12 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
                 height="200px"
                 extensions={[json()]}
                 onChange={onCodeFieldChange}
+                style={{
+                    border: `1px solid ${theme.palette.lightBorder}`,
+                    borderTop: 'none',
+                    borderBottomLeftRadius: '3px',
+                    borderBottomRightRadius: '3px',
+                }}
                 placeholder={JSON.stringify(
                     {
                         currentTime: '2022-07-04T14:13:03.929Z',

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -89,7 +89,7 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
     return (
         <Box sx={{ width: '100%' }}>
             <StyledEditorHeader>
-                Json
+                JSON
                 <ConditionallyRender
                     condition={Boolean(error)}
                     show={

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -49,7 +49,7 @@ const EditorStatusOk = () => {
     return (
         <StyledEditorStatusContainer
             style={{
-                color: '#fff',
+                color: theme.palette.text.tertiaryContrast,
                 backgroundColor: theme.palette.success.main,
             }}
         >
@@ -64,7 +64,7 @@ const EditorStatusError = () => {
     return (
         <StyledEditorStatusContainer
             style={{
-                color: '#fff',
+                color: theme.palette.text.tertiaryContrast,
                 backgroundColor: theme.palette.error.main,
             }}
         >

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundCodeFieldset/PlaygroundEditor/PlaygroundEditor.tsx
@@ -84,7 +84,7 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
     );
 
     return (
-        <div>
+        <Box sx={{ width: '100%' }}>
             <StyledEditorHeader>
                 Json
                 <ConditionallyRender
@@ -114,6 +114,6 @@ export const PlaygroundEditor: VFC<IPlaygroundEditorProps> = ({
                     2
                 )}
             />
-        </div>
+        </Box>
     );
 };

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundConnectionFieldset/PlaygroundConnectionFieldset.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material';
 import { useEnvironments } from 'hooks/api/getters/useEnvironments/useEnvironments';
 import useProjects from 'hooks/api/getters/useProjects/useProjects';
+import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
 
 interface IPlaygroundConnectionFieldsetProps {
     environment: string;
@@ -76,19 +77,22 @@ export const PlaygroundConnectionFieldset: VFC<
 
     return (
         <Box sx={{ pb: 2 }}>
-            <Typography
-                variant="body2"
-                sx={{ mb: 2 }}
-                color={theme.palette.text.secondary}
-            >
-                Access configuration
-            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                <GuidanceIndicator type="secondary">1</GuidanceIndicator>
+                <Typography
+                    variant="body2"
+                    color={theme.palette.text.secondary}
+                    sx={{ ml: 1 }}
+                >
+                    Access configuration
+                </Typography>
+            </Box>
             <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
                 <Autocomplete
                     disablePortal
                     id="environment"
                     options={environmentOptions}
-                    sx={{ width: 300, maxWidth: '100%' }}
+                    sx={{ width: 200, maxWidth: '100%' }}
                     renderInput={params => (
                         <TextField {...params} label="Environment" required />
                     )}
@@ -101,7 +105,7 @@ export const PlaygroundConnectionFieldset: VFC<
                     id="projects"
                     multiple={!isAllProjects}
                     options={projectsOptions}
-                    sx={{ width: 300, maxWidth: '100%' }}
+                    sx={{ width: 200, maxWidth: '100%' }}
                     renderInput={params => (
                         <TextField {...params} label="Projects" />
                     )}

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
@@ -33,7 +33,10 @@ export const PlaygroundForm: VFC<IPlaygroundFormProps> = ({
         <Box
             component="form"
             onSubmit={onSubmit}
-            sx={{ display: 'flex', flexDirection: 'column' }}
+            sx={{
+                display: 'flex',
+                flexDirection: 'column',
+            }}
         >
             <PlaygroundConnectionFieldset
                 environment={environment}

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
@@ -1,11 +1,4 @@
-import {
-    Box,
-    Button,
-    Divider,
-    Paper,
-    Typography,
-    useTheme,
-} from '@mui/material';
+import { Box, Button, Divider, useTheme } from '@mui/material';
 import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
 import { IEnvironment } from 'interfaces/environments';
 import { FormEvent, VFC } from 'react';

--- a/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
+++ b/src/component/playground/Playground/PlaygroundForm/PlaygroundForm.tsx
@@ -1,0 +1,90 @@
+import {
+    Box,
+    Button,
+    Divider,
+    Paper,
+    Typography,
+    useTheme,
+} from '@mui/material';
+import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
+import { IEnvironment } from 'interfaces/environments';
+import { FormEvent, VFC } from 'react';
+import { getEnvironmentOptions } from '../playground.utils';
+import { PlaygroundCodeFieldset } from './PlaygroundCodeFieldset/PlaygroundCodeFieldset';
+import { PlaygroundConnectionFieldset } from './PlaygroundConnectionFieldset/PlaygroundConnectionFieldset';
+
+interface IPlaygroundFormProps {
+    environments: IEnvironment[];
+    onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+    environment: string;
+    projects: string[];
+    setProjects: React.Dispatch<React.SetStateAction<string[]>>;
+    setEnvironment: React.Dispatch<React.SetStateAction<string>>;
+    context: string | undefined;
+    setContext: React.Dispatch<React.SetStateAction<string | undefined>>;
+}
+
+export const PlaygroundForm: VFC<IPlaygroundFormProps> = ({
+    environments,
+    environment,
+    onSubmit,
+    projects,
+    setProjects,
+    setEnvironment,
+    context,
+    setContext,
+}) => {
+    const theme = useTheme();
+
+    return (
+        <Box
+            component="form"
+            onSubmit={onSubmit}
+            sx={{ display: 'flex', flexDirection: 'column' }}
+        >
+            <PlaygroundConnectionFieldset
+                environment={environment}
+                projects={projects}
+                setEnvironment={setEnvironment}
+                setProjects={setProjects}
+                environmentOptions={getEnvironmentOptions(environments)}
+            />
+            <Divider
+                variant="fullWidth"
+                sx={{
+                    mb: 2,
+                    borderColor: theme.palette.dividerAlternative,
+                    borderStyle: 'dashed',
+                }}
+            />
+            <PlaygroundCodeFieldset context={context} setContext={setContext} />
+
+            <Divider
+                variant="fullWidth"
+                sx={{
+                    mt: 3,
+                    mb: 2,
+                    borderColor: theme.palette.dividerAlternative,
+                }}
+            />
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                }}
+            >
+                <GuidanceIndicator type="secondary">3</GuidanceIndicator>
+
+                <Button
+                    variant="contained"
+                    size="large"
+                    type="submit"
+                    sx={{ marginLeft: 'auto' }}
+                >
+                    Try configuration
+                </Button>
+            </Box>
+        </Box>
+    );
+};

--- a/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
+++ b/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
@@ -1,0 +1,45 @@
+import { Typography, Box, Divider } from '@mui/material';
+import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
+import { PlaygroundGuidanceSection } from './PlaygroundGuidanceSection/PlaygroundGuidanceSection';
+
+export const PlaygroundGuidance = () => {
+    return (
+        <Box>
+            <Typography variant="body1">
+                Unleash playground is for helping you to undestand how unleash
+                works, how feature toggles are evaluated and for you to easily
+                debug your feature toggles.
+            </Typography>
+
+            <Divider sx={{ mt: 2, mb: 2 }} />
+
+            <Typography variant="body1" sx={{ mb: 1 }}>
+                What you need to do is:
+            </Typography>
+
+            <PlaygroundGuidanceSection
+                headerText="  Select in which environment you want to test your
+                            feature toggle configuration"
+                bodyText="  You can also specify specific projects, or check
+                            toggles in all projects."
+                sectionNumber="1"
+            />
+
+            <PlaygroundGuidanceSection
+                headerText="Select a context field that you'd like to check"
+                bodyText="Configure multiple context fields or leave empty to test against an empty context"
+                sectionNumber="2"
+            />
+
+            <PlaygroundGuidanceSection
+                headerText="Try configuration"
+                sectionNumber="3"
+            />
+
+            <PlaygroundGuidanceSection
+                headerText="View the results"
+                sectionNumber="4"
+            />
+        </Box>
+    );
+};

--- a/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
+++ b/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
@@ -17,27 +17,23 @@ export const PlaygroundGuidance = () => {
             </Typography>
 
             <PlaygroundGuidanceSection
-                headerText="  Select in which environment you want to test your
+                headerText="Select in which environment you want to test your
                             feature toggle configuration"
-                bodyText="  You can also specify specific projects, or check
+                bodyText="You can also specify specific projects, or check
                             toggles in all projects."
                 sectionNumber="1"
             />
 
             <PlaygroundGuidanceSection
                 headerText="Select a context field that you'd like to check"
-                bodyText="Configure multiple context fields or leave empty to test against an empty context"
+                bodyText="You can configure as many context fields context fields as you want. You can also leave the context empty to test against an empty context."
                 sectionNumber="2"
             />
 
             <PlaygroundGuidanceSection
-                headerText="Try configuration"
+                headerText="Submit the form to try the configuration"
+                bodyText="The results of evaluating your feature toggles will appear after you submit the form. Then view the results."
                 sectionNumber="3"
-            />
-
-            <PlaygroundGuidanceSection
-                headerText="View the results"
-                sectionNumber="4"
             />
         </Box>
     );

--- a/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
+++ b/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidance.tsx
@@ -1,10 +1,9 @@
 import { Typography, Box, Divider } from '@mui/material';
-import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
 import { PlaygroundGuidanceSection } from './PlaygroundGuidanceSection/PlaygroundGuidanceSection';
 
 export const PlaygroundGuidance = () => {
     return (
-        <Box>
+        <Box sx={{ ml: 4 }}>
             <Typography variant="body1">
                 Unleash playground is for helping you to undestand how unleash
                 works, how feature toggles are evaluated and for you to easily

--- a/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidanceSection/PlaygroundGuidanceSection.tsx
+++ b/src/component/playground/Playground/PlaygroundGuidance/PlaygroundGuidanceSection/PlaygroundGuidanceSection.tsx
@@ -1,0 +1,44 @@
+import { Box, Typography } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
+import { VFC } from 'react';
+
+interface IPlaygroundGuidanceSectionProps {
+    headerText: string;
+    bodyText?: string;
+    sectionNumber: string;
+}
+
+export const PlaygroundGuidanceSection: VFC<
+    IPlaygroundGuidanceSectionProps
+> = ({ headerText, bodyText, sectionNumber }) => {
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                mt: 2,
+                flexDirection: 'column',
+            }}
+        >
+            <Box sx={{ display: 'flex' }}>
+                <Box>
+                    <GuidanceIndicator>{sectionNumber}</GuidanceIndicator>
+                </Box>
+                <Box sx={{ ml: 2, display: 'flex', flexDirection: 'column' }}>
+                    <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+                        {headerText}
+                    </Typography>
+                    <ConditionallyRender
+                        condition={Boolean(bodyText)}
+                        show={
+                            <Typography variant="body1" sx={{ mt: 1 }}>
+                                {bodyText}
+                            </Typography>
+                        }
+                    />
+                </Box>
+            </Box>
+        </Box>
+    );
+};

--- a/src/component/playground/Playground/PlaygroundGuidancePopper/PlaygroundGuidancePopper.tsx
+++ b/src/component/playground/Playground/PlaygroundGuidancePopper/PlaygroundGuidancePopper.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+
+import { Close, Help } from '@mui/icons-material';
+import { Box, IconButton, Popper, Paper } from '@mui/material';
+import { PlaygroundGuidance } from '../PlaygroundGuidance/PlaygroundGuidance';
+
+export const PlaygroundGuidancePopper = () => {
+    const [anchor, setAnchorEl] = useState<null | Element>(null);
+
+    const onOpen = (event: React.FormEvent<HTMLButtonElement>) =>
+        setAnchorEl(event.currentTarget);
+
+    const onClose = () => setAnchorEl(null);
+
+    const open = Boolean(anchor);
+
+    const id = 'playground-guidance-popper';
+
+    return (
+        <Box>
+            <IconButton onClick={onOpen} aria-describedby={id}>
+                <Help />
+            </IconButton>
+
+            <Popper
+                id={id}
+                open={open}
+                anchorEl={anchor}
+                sx={theme => ({ zIndex: theme.zIndex.tooltip })}
+            >
+                <Paper
+                    sx={theme => ({
+                        padding: theme.spacing(8, 4),
+                        maxWidth: '500px',
+                        borderRadius: theme.shape.borderRadiusExtraLarge,
+                    })}
+                >
+                    <IconButton
+                        onClick={onClose}
+                        sx={{ position: 'absolute', right: 25, top: 15 }}
+                    >
+                        <Close />
+                    </IconButton>
+                    <PlaygroundGuidance />
+                </Paper>
+            </Popper>
+        </Box>
+    );
+};

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -57,7 +57,7 @@ export const PlaygroundResultsTable = ({
             ? Array(5).fill({
                   name: 'Feature name',
                   projectId: 'FeatureProject',
-                  variant: { name: 'FeatureVariant' },
+                  variant: { name: 'FeatureVariant', variants: [] },
                   enabled: true,
               })
             : searchedData;
@@ -216,7 +216,7 @@ const COLUMNS = [
         Header: 'Name',
         accessor: 'name',
         searchable: true,
-        width: '60%',
+        minWidth: 160,
         Cell: ({ value, row: { original } }: any) => (
             <LinkCell
                 title={value}
@@ -242,16 +242,18 @@ const COLUMNS = [
         sortType: 'alphanumeric',
         filterName: 'variant',
         searchable: true,
-        maxWidth: 170,
+        width: 200,
         Cell: ({
             value,
             row: {
-                original: { variant },
+                original: { variant, feature, variants, isEnabled },
             },
         }: any) => (
             <VariantCell
                 variant={variant?.enabled ? value : ''}
-                variants={[]}
+                variants={variants}
+                feature={feature}
+                isEnabled={isEnabled}
             />
         ),
     },
@@ -260,7 +262,6 @@ const COLUMNS = [
         accessor: 'isEnabled',
         filterName: 'isEnabled',
         filterParsing: (value: boolean) => (value ? 'true' : 'false'),
-        maxWidth: 170,
         Cell: ({ value }: any) => <FeatureStatusCell enabled={value} />,
         sortType: 'boolean',
         sortInverted: true,

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { SortingRule, useGlobalFilter, useSortBy, useTable } from 'react-table';
-import { PageContent } from 'component/common/PageContent/PageContent';
-import { PageHeader } from 'component/common/PageHeader/PageHeader';
+
 import {
     SortableTableHeader,
     Table,
@@ -21,6 +20,9 @@ import { useSearch } from 'hooks/useSearch';
 import { createLocalStorage } from 'utils/createLocalStorage';
 import { FeatureStatusCell } from './FeatureStatusCell/FeatureStatusCell';
 import { PlaygroundFeatureSchema } from 'hooks/api/actions/usePlayground/playground.model';
+import { Box, Typography } from '@mui/material';
+import useLoading from 'hooks/useLoading';
+import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
 
 const defaultSort: SortingRule<string> = { id: 'name' };
 const { value, setValue } = createLocalStorage(
@@ -38,7 +40,7 @@ export const PlaygroundResultsTable = ({
     loading,
 }: IPlaygroundResultsTableProps) => {
     const [searchParams, setSearchParams] = useSearchParams();
-
+    const ref = useLoading(loading);
     const [searchValue, setSearchValue] = useState(
         searchParams.get('search') || ''
     );
@@ -122,31 +124,37 @@ export const PlaygroundResultsTable = ({
     }, [loading, sortBy, searchValue]);
 
     return (
-        <PageContent
-            header={
-                <PageHeader
-                    titleElement={
-                        features !== undefined
+        <Box sx={theme => ({ padding: theme.spacing(4, 2) })}>
+            <Box
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    mb: 3,
+                }}
+            >
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <GuidanceIndicator type="secondary">4</GuidanceIndicator>
+                    <Typography variant="subtitle1" sx={{ ml: 1 }}>
+                        {features !== undefined && !loading
                             ? `Results (${
                                   rows.length < data.length
                                       ? `${rows.length} of ${data.length}`
                                       : data.length
                               })`
-                            : 'Results'
-                    }
-                    actions={
-                        <Search
-                            initialValue={searchValue}
-                            onChange={setSearchValue}
-                            hasFilters
-                            getSearchContext={getSearchContext}
-                            disabled={loading}
-                        />
-                    }
+                            : 'Results'}
+                    </Typography>
+                </Box>
+
+                <Search
+                    initialValue={searchValue}
+                    onChange={setSearchValue}
+                    hasFilters
+                    getSearchContext={getSearchContext}
+                    disabled={loading}
                 />
-            }
-            isLoading={loading}
-        >
+            </Box>
+
             <ConditionallyRender
                 condition={!loading && (!data || data.length === 0)}
                 show={() => (
@@ -157,7 +165,7 @@ export const PlaygroundResultsTable = ({
                     </TablePlaceholder>
                 )}
                 elseShow={() => (
-                    <>
+                    <Box ref={ref}>
                         <SearchHighlightProvider
                             value={getSearchText(searchValue)}
                         >
@@ -195,10 +203,10 @@ export const PlaygroundResultsTable = ({
                                 </TablePlaceholder>
                             }
                         />
-                    </>
+                    </Box>
                 )}
             />
-        </PageContent>
+        </Box>
     );
 };
 

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -168,6 +168,7 @@ export const PlaygroundResultsTable = ({
                     hasFilters
                     getSearchContext={getSearchContext}
                     disabled={loading}
+                    styles={{ marginLeft: "1rem", maxWidth: "400px"}}
                 />
             </Box>
 

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -196,7 +196,9 @@ export const PlaygroundResultsTable = ({
                             </Table>
                         </SearchHighlightProvider>
                         <ConditionallyRender
-                            condition={data.length === 0}
+                            condition={
+                                data.length === 0 && searchValue?.length > 0
+                            }
                             show={
                                 <TablePlaceholder>
                                     No feature toggles found matching &ldquo;

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -23,6 +23,7 @@ import { PlaygroundFeatureSchema } from 'hooks/api/actions/usePlayground/playgro
 import { Box, Typography } from '@mui/material';
 import useLoading from 'hooks/useLoading';
 import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
+import { VariantCell } from './VariantCell/VariantCell';
 
 const defaultSort: SortingRule<string> = { id: 'name' };
 const { value, setValue } = createLocalStorage(
@@ -247,7 +248,12 @@ const COLUMNS = [
             row: {
                 original: { variant },
             },
-        }: any) => <HighlightCell value={variant?.enabled ? value : ''} />,
+        }: any) => (
+            <VariantCell
+                variant={variant?.enabled ? value : ''}
+                variants={[]}
+            />
+        ),
     },
     {
         Header: 'isEnabled',

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -168,7 +168,7 @@ export const PlaygroundResultsTable = ({
                     hasFilters
                     getSearchContext={getSearchContext}
                     disabled={loading}
-                    styles={{ marginLeft: "1rem", maxWidth: "400px"}}
+                    containerStyles={{ marginLeft: '1rem', maxWidth: '400px' }}
                 />
             </Box>
 

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -20,7 +20,7 @@ import { useSearch } from 'hooks/useSearch';
 import { createLocalStorage } from 'utils/createLocalStorage';
 import { FeatureStatusCell } from './FeatureStatusCell/FeatureStatusCell';
 import { PlaygroundFeatureSchema } from 'hooks/api/actions/usePlayground/playground.model';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 import useLoading from 'hooks/useLoading';
 import { GuidanceIndicator } from 'component/common/GuidanceIndicator/GuidanceIndicator';
 import { VariantCell } from './VariantCell/VariantCell';
@@ -45,6 +45,9 @@ export const PlaygroundResultsTable = ({
     const [searchValue, setSearchValue] = useState(
         searchParams.get('search') || ''
     );
+    const theme = useTheme();
+    const isExtraSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+    const isSmallScreen = useMediaQuery(theme.breakpoints.down('md'));
 
     const {
         data: searchedData,
@@ -81,6 +84,7 @@ export const PlaygroundResultsTable = ({
         state: { sortBy },
         rows,
         prepareRow,
+        setHiddenColumns,
     } = useTable(
         {
             initialState,
@@ -97,6 +101,17 @@ export const PlaygroundResultsTable = ({
         useGlobalFilter,
         useSortBy
     );
+
+    useEffect(() => {
+        const hiddenColumns = [];
+        if (isSmallScreen) {
+            hiddenColumns.push('projectId');
+        }
+        if (isExtraSmallScreen) {
+            hiddenColumns.push('variant');
+        }
+        setHiddenColumns(hiddenColumns);
+    }, [setHiddenColumns, isExtraSmallScreen, isSmallScreen]);
 
     useEffect(() => {
         if (loading) {

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -244,6 +244,8 @@ const COLUMNS = [
     {
         Header: 'isEnabled',
         accessor: 'isEnabled',
+        filterName: 'isEnabled',
+        filterParsing: (value: boolean) => (value ? 'true' : 'false'),
         maxWidth: 170,
         Cell: ({ value }: any) => <FeatureStatusCell enabled={value} />,
         sortType: 'boolean',

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -187,7 +187,7 @@ export const PlaygroundResultsTable = ({
                             </Table>
                         </SearchHighlightProvider>
                         <ConditionallyRender
-                            condition={searchValue?.length > 0}
+                            condition={data.length === 0}
                             show={
                                 <TablePlaceholder>
                                     No feature toggles found matching &ldquo;

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -157,7 +157,7 @@ export const PlaygroundResultsTable = ({
             </Box>
 
             <ConditionallyRender
-                condition={!loading && (!data || data.length === 0)}
+                condition={!loading && !data}
                 show={() => (
                     <TablePlaceholder>
                         {data === undefined

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -124,7 +124,7 @@ export const PlaygroundResultsTable = ({
     }, [loading, sortBy, searchValue]);
 
     return (
-        <Box sx={theme => ({ padding: theme.spacing(4, 2) })}>
+        <>
             <Box
                 sx={{
                     display: 'flex',
@@ -206,7 +206,7 @@ export const PlaygroundResultsTable = ({
                     </Box>
                 )}
             />
-        </Box>
+        </>
     );
 };
 

--- a/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/PlaygroundResultsTable.tsx
@@ -149,18 +149,15 @@ export const PlaygroundResultsTable = ({
                     mb: 3,
                 }}
             >
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    <GuidanceIndicator type="secondary">4</GuidanceIndicator>
-                    <Typography variant="subtitle1" sx={{ ml: 1 }}>
-                        {features !== undefined && !loading
-                            ? `Results (${
-                                  rows.length < data.length
-                                      ? `${rows.length} of ${data.length}`
-                                      : data.length
-                              })`
-                            : 'Results'}
-                    </Typography>
-                </Box>
+                <Typography variant="subtitle1" sx={{ ml: 1 }}>
+                    {features !== undefined && !loading
+                        ? `Results (${
+                              rows.length < data.length
+                                  ? `${rows.length} of ${data.length}`
+                                  : data.length
+                          })`
+                        : 'Results'}
+                </Typography>
 
                 <Search
                     initialValue={searchValue}
@@ -219,6 +216,17 @@ export const PlaygroundResultsTable = ({
                                 <TablePlaceholder>
                                     No feature toggles found matching &ldquo;
                                     {searchValue}&rdquo;
+                                </TablePlaceholder>
+                            }
+                        />
+
+                        <ConditionallyRender
+                            condition={
+                                data && data.length === 0 && !searchValue
+                            }
+                            show={
+                                <TablePlaceholder>
+                                    No features toggles to display
                                 </TablePlaceholder>
                             }
                         />

--- a/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
@@ -1,14 +1,23 @@
-import { InfoOutlined, ViewAgenda } from '@mui/icons-material';
+import { InfoOutlined } from '@mui/icons-material';
 import { IconButton, Popover } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { useState, VFC } from 'react';
+import { VariantInformation } from './VariantInformation/VariantInformation';
+import { IFeatureVariant } from 'interfaces/featureToggle';
 
 interface IVariantCellProps {
     variant: string;
-    variants: any[];
+    variants: IFeatureVariant[];
+    feature: string;
+    isEnabled: boolean;
 }
 
-export const VariantCell: VFC<IVariantCellProps> = ({ variant, variants }) => {
+export const VariantCell: VFC<IVariantCellProps> = ({
+    variant,
+    variants,
+    feature,
+    isEnabled,
+}) => {
     const [anchor, setAnchorEl] = useState(null);
 
     const onOpen = (event: any) => setAnchorEl(event.currentTarget);
@@ -17,10 +26,19 @@ export const VariantCell: VFC<IVariantCellProps> = ({ variant, variants }) => {
 
     const open = Boolean(anchor);
     return (
-        <div>
+        <div
+            style={{
+                maxWidth: '100%',
+                display: 'flex',
+                alignItems: 'center',
+                wordBreak: 'break-all',
+            }}
+        >
             {variant}
             <ConditionallyRender
-                condition={Boolean(variants)}
+                condition={
+                    Boolean(variants) && variants.length > 0 && isEnabled
+                }
                 show={
                     <>
                         <IconButton onClick={onOpen}>
@@ -29,15 +47,18 @@ export const VariantCell: VFC<IVariantCellProps> = ({ variant, variants }) => {
 
                         <Popover
                             open={open}
-                            id="myid"
+                            id={`${feature}-result-variants`}
                             onClose={onClose}
                             anchorEl={anchor}
                             anchorOrigin={{
                                 vertical: 'bottom',
-                                horizontal: -120,
+                                horizontal: -320,
                             }}
                         >
-                            <p>This is the popover!</p>
+                            <VariantInformation
+                                variants={variants}
+                                selectedVariant={variant}
+                            />
                         </Popover>
                     </>
                 }

--- a/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
@@ -1,7 +1,7 @@
 import { InfoOutlined } from '@mui/icons-material';
-import { IconButton, Popover } from '@mui/material';
+import { IconButton, Popover, styled } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
-import { useState, VFC } from 'react';
+import React, { useState, VFC } from 'react';
 import { VariantInformation } from './VariantInformation/VariantInformation';
 import { IFeatureVariant } from 'interfaces/featureToggle';
 
@@ -12,28 +12,30 @@ interface IVariantCellProps {
     isEnabled: boolean;
 }
 
+const StyledDiv = styled('div')(() => ({
+    maxWidth: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    wordBreak: 'break-all',
+}));
+
 export const VariantCell: VFC<IVariantCellProps> = ({
     variant,
     variants,
     feature,
     isEnabled,
 }) => {
-    const [anchor, setAnchorEl] = useState(null);
+    const [anchor, setAnchorEl] = useState<null | Element>(null);
 
-    const onOpen = (event: any) => setAnchorEl(event.currentTarget);
+    const onOpen = (event: React.FormEvent<HTMLButtonElement>) =>
+        setAnchorEl(event.currentTarget);
 
     const onClose = () => setAnchorEl(null);
 
     const open = Boolean(anchor);
+
     return (
-        <div
-            style={{
-                maxWidth: '100%',
-                display: 'flex',
-                alignItems: 'center',
-                wordBreak: 'break-all',
-            }}
-        >
+        <StyledDiv>
             {variant}
             <ConditionallyRender
                 condition={
@@ -63,6 +65,6 @@ export const VariantCell: VFC<IVariantCellProps> = ({
                     </>
                 }
             />
-        </div>
+        </StyledDiv>
     );
 };

--- a/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
@@ -1,0 +1,47 @@
+import { InfoOutlined, ViewAgenda } from '@mui/icons-material';
+import { IconButton, Popover } from '@mui/material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useState, VFC } from 'react';
+
+interface IVariantCellProps {
+    variant: string;
+    variants: any[];
+}
+
+export const VariantCell: VFC<IVariantCellProps> = ({ variant, variants }) => {
+    const [anchor, setAnchorEl] = useState(null);
+
+    const onOpen = (event: any) => setAnchorEl(event.currentTarget);
+
+    const onClose = () => setAnchorEl(null);
+
+    const open = Boolean(anchor);
+    return (
+        <div>
+            {variant}
+            <ConditionallyRender
+                condition={Boolean(variants)}
+                show={
+                    <>
+                        <IconButton onClick={onOpen}>
+                            <InfoOutlined />
+                        </IconButton>
+
+                        <Popover
+                            open={open}
+                            id="myid"
+                            onClose={onClose}
+                            anchorEl={anchor}
+                            anchorOrigin={{
+                                vertical: 'bottom',
+                                horizontal: -120,
+                            }}
+                        >
+                            <p>This is the popover!</p>
+                        </Popover>
+                    </>
+                }
+            />
+        </div>
+    );
+};

--- a/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantCell.tsx
@@ -1,5 +1,5 @@
 import { InfoOutlined } from '@mui/icons-material';
-import { IconButton, Popover, styled } from '@mui/material';
+import { IconButton, Popover, styled, useTheme } from '@mui/material';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import React, { useState, VFC } from 'react';
 import { VariantInformation } from './VariantInformation/VariantInformation';
@@ -25,6 +25,7 @@ export const VariantCell: VFC<IVariantCellProps> = ({
     feature,
     isEnabled,
 }) => {
+    const theme = useTheme();
     const [anchor, setAnchorEl] = useState<null | Element>(null);
 
     const onOpen = (event: React.FormEvent<HTMLButtonElement>) =>
@@ -50,6 +51,12 @@ export const VariantCell: VFC<IVariantCellProps> = ({
                         <Popover
                             open={open}
                             id={`${feature}-result-variants`}
+                            PaperProps={{
+                                sx: {
+                                    borderRadius:
+                                        theme.shape.borderRadiusExtraLarge,
+                                },
+                            }}
                             onClose={onClose}
                             anchorEl={anchor}
                             anchorOrigin={{

--- a/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
@@ -18,7 +18,6 @@ interface IVariantInformationProps {
 
 const StyledBox = styled('div')(({ theme }) => ({
     padding: theme.spacing(4),
-    borderRadius: '5px',
     maxWidth: '400px',
 }));
 

--- a/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
+++ b/src/component/playground/Playground/PlaygroundResultsTable/VariantCell/VariantInformation/VariantInformation.tsx
@@ -1,0 +1,160 @@
+import { Typography, styled, useTheme } from '@mui/material';
+import { Table, TableBody, TableCell, TableRow } from 'component/common/Table';
+import { useMemo, VFC } from 'react';
+import { IFeatureVariant } from 'interfaces/featureToggle';
+import { calculateVariantWeight } from 'component/common/util';
+import { useGlobalFilter, useSortBy, useTable } from 'react-table';
+import { sortTypes } from 'utils/sortTypes';
+import { TextCell } from 'component/common/Table/cells/TextCell/TextCell';
+import { SortableTableHeader } from 'component/common/Table';
+import { CheckCircleOutlined } from '@mui/icons-material';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { IconCell } from 'component/common/Table/cells/IconCell/IconCell';
+
+interface IVariantInformationProps {
+    variants: IFeatureVariant[];
+    selectedVariant: string;
+}
+
+const StyledBox = styled('div')(({ theme }) => ({
+    padding: theme.spacing(4),
+    borderRadius: '5px',
+    maxWidth: '400px',
+}));
+
+const StyledTypography = styled(Typography)(({ theme }) => ({
+    marginBottom: theme.spacing(2),
+}));
+
+const StyledCheckIcon = styled(CheckCircleOutlined)(({ theme }) => ({
+    color: theme.palette.success.main,
+}));
+
+export const VariantInformation: VFC<IVariantInformationProps> = ({
+    variants,
+    selectedVariant,
+}) => {
+    const theme = useTheme();
+    const data = useMemo(() => {
+        return variants.map(variant => {
+            return {
+                name: variant.name,
+                weight: `${calculateVariantWeight(variant.weight)}%`,
+                selected: variant.name === selectedVariant,
+            };
+        });
+    }, [variants, selectedVariant]);
+
+    const initialState = useMemo(
+        () => ({
+            sortBy: [{ id: 'name', desc: false }],
+        }),
+        []
+    );
+
+    const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
+        useTable(
+            {
+                initialState,
+                columns: COLUMNS as any,
+                data: data as any,
+                sortTypes,
+                autoResetGlobalFilter: false,
+                autoResetSortBy: false,
+                disableSortRemove: true,
+            },
+            useGlobalFilter,
+            useSortBy
+        );
+
+    return (
+        <StyledBox>
+            <StyledTypography variant="subtitle2">
+                Variant Information
+            </StyledTypography>
+
+            <StyledTypography variant="body2">
+                The following table shows the variants defined on this feature
+                toggle and the variant result based on your context
+                configuration.
+            </StyledTypography>
+
+            <StyledTypography variant="body2">
+                If you include "userId" or "sessionId" in your context, the
+                variant will be the same every time because unleash uses these
+                properties to ensure that the user receives the same experience.
+            </StyledTypography>
+
+            <Table {...getTableProps()} rowHeight="dense">
+                <SortableTableHeader headerGroups={headerGroups as any} />
+                <TableBody {...getTableBodyProps()}>
+                    {rows.map((row: any) => {
+                        let styles = {} as { [key: string]: string };
+
+                        if (!row.original.selected) {
+                            styles.color = theme.palette.text.secondary;
+                        }
+
+                        prepareRow(row);
+                        return (
+                            <TableRow hover {...row.getRowProps()}>
+                                {row.cells.map((cell: any) => (
+                                    <TableCell
+                                        {...cell.getCellProps()}
+                                        style={styles}
+                                    >
+                                        {cell.render('Cell')}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        );
+                    })}
+                </TableBody>
+            </Table>
+        </StyledBox>
+    );
+};
+
+const COLUMNS = [
+    {
+        id: 'Icon',
+        Cell: ({
+            row: {
+                original: { selected },
+            },
+        }: any) => (
+            <>
+                <ConditionallyRender
+                    condition={selected}
+                    show={<IconCell icon={<StyledCheckIcon />} />}
+                />
+            </>
+        ),
+        maxWidth: 25,
+        disableGlobalFilter: true,
+    },
+    {
+        Header: 'Name',
+        accessor: 'name',
+        searchable: true,
+        Cell: ({
+            row: {
+                original: { name },
+            },
+        }: any) => <TextCell>{name}</TextCell>,
+        maxWidth: 175,
+        width: 175,
+    },
+    {
+        Header: 'Weight',
+        accessor: 'weight',
+        sortType: 'alphanumeric',
+        searchable: true,
+        maxWidth: 75,
+        Cell: ({
+            row: {
+                original: { weight },
+            },
+        }: any) => <TextCell>{weight}</TextCell>,
+    },
+];

--- a/src/component/playground/Playground/playground.utils.ts
+++ b/src/component/playground/Playground/playground.utils.ts
@@ -1,3 +1,4 @@
+import { PlaygroundResponseSchema } from 'hooks/api/actions/usePlayground/playground.model';
 import { IEnvironment } from 'interfaces/environments';
 
 export const resolveProjects = (
@@ -25,4 +26,19 @@ export const getEnvironmentOptions = (environments: IEnvironment[]) => {
         .filter(({ enabled }) => Boolean(enabled))
         .sort((a, b) => a.sortOrder - b.sortOrder)
         .map(({ name }) => name);
+};
+
+export const resolveResultsWidth = (
+    matches: boolean,
+    results: PlaygroundResponseSchema | undefined
+) => {
+    if (matches) {
+        return '100%';
+    }
+
+    if (results && !matches) {
+        return '65%';
+    }
+
+    return '50%';
 };

--- a/src/component/playground/Playground/playground.utils.ts
+++ b/src/component/playground/Playground/playground.utils.ts
@@ -1,0 +1,28 @@
+import { IEnvironment } from 'interfaces/environments';
+
+export const resolveProjects = (
+    projects: string[] | string
+): string[] | string => {
+    return !projects ||
+        projects.length === 0 ||
+        (projects.length === 1 && projects[0] === '*')
+        ? '*'
+        : projects;
+};
+
+export const resolveDefaultEnvironment = (
+    environmentOptions: IEnvironment[]
+) => {
+    const options = getEnvironmentOptions(environmentOptions);
+    if (options.length > 0) {
+        return options[0];
+    }
+    return '';
+};
+
+export const getEnvironmentOptions = (environments: IEnvironment[]) => {
+    return environments
+        .filter(({ enabled }) => Boolean(enabled))
+        .sort((a, b) => a.sortOrder - b.sortOrder)
+        .map(({ name }) => name);
+};

--- a/src/hooks/api/actions/usePlayground/usePlayground.ts
+++ b/src/hooks/api/actions/usePlayground/usePlayground.ts
@@ -4,7 +4,7 @@ import {
     PlaygroundResponseSchema,
 } from './playground.model';
 
-const usePlaygroundApi = () => {
+export const usePlaygroundApi = () => {
     const { makeRequest, createRequest, errors, loading } = useAPI({
         propagateErrors: true,
     });
@@ -33,5 +33,3 @@ const usePlaygroundApi = () => {
         loading,
     };
 };
-
-export default usePlaygroundApi;

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -103,6 +103,7 @@ export default createTheme({
         secondaryContainer: colors.grey[200],
         sidebarContainer: 'rgba(32,32,33, 0.2)',
         grey: colors.grey,
+        lightBorder: colors.grey[400],
         text: {
             primary: colors.grey[900],
             secondary: colors.grey[800],

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -91,6 +91,11 @@ export default createTheme({
             dark: colors.grey[800],
             border: colors.grey[500],
         },
+        tertiary: {
+            light: colors.grey[200],
+            main: colors.grey[400],
+            dark: colors.grey[600],
+        },
         divider: colors.grey[300],
         dividerAlternative: colors.grey[400],
         tableHeaderHover: colors.grey[400],
@@ -102,6 +107,7 @@ export default createTheme({
             primary: colors.grey[900],
             secondary: colors.grey[800],
             disabled: colors.grey[600],
+            tertiaryContrast: '#fff',
         },
         code: {
             main: '#0b8c8f',

--- a/src/themes/themeTypes.ts
+++ b/src/themes/themeTypes.ts
@@ -79,6 +79,16 @@ declare module '@mui/material/styles' {
          * and not with `import YourIcon from "@mui/icons/YourIcon"`.
          */
         inactiveIcon: string;
+
+        tertiary: {
+            main: string;
+            light: string;
+            dark: string;
+        };
+    }
+
+    interface CustomTypeText {
+        tertiaryContrast: string;
     }
 
     interface Theme extends CustomTheme {}
@@ -86,6 +96,8 @@ declare module '@mui/material/styles' {
 
     interface Palette extends CustomPalette {}
     interface PaletteOptions extends CustomPalette {}
+
+    interface TypeText extends CustomTypeText {}
 
     interface PaletteColor {
         light: string;

--- a/src/themes/themeTypes.ts
+++ b/src/themes/themeTypes.ts
@@ -80,6 +80,10 @@ declare module '@mui/material/styles' {
          */
         inactiveIcon: string;
 
+        /** A border color used for contrast between similar backgroundColors **/
+        lightBorder: string;
+
+        /* Type for tertiary colors */
         tertiary: {
             main: string;
             light: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.18.6":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -1079,6 +1086,88 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
+
+"@codemirror/autocomplete@^6.0.0":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.0.4.tgz#90a9c81cfddac528b9e9dc07415a7c6554dbe85c"
+  integrity sha512-uP7UodCRykPNwSAN+wYa/AS9gJI/V47echCAXUYgCgBXy3l19nwO7W/d29COtG/dfAsjBOhMDeh3Ms8Y5VZbrA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.0.1.tgz#c005dd2dab2f6d90ad00d4a25bfeaaec2393efa6"
+  integrity sha512-iNHDByicYqQjs0Wo1MKGfqNbMYMyhS9WV6EwMVwsHXImlFemgEUC+c5X22bXKBStN3qnwg4fArNZM+gkv22baQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/lang-json@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-json/-/lang-json-6.0.0.tgz#6ac373248c2d44ceab6d5d58879cc543095e503e"
+  integrity sha512-DvTcYTKLmg2viADXlTdufrT334M9jowe1qO02W28nvm+nejcvhM5vot5mE8/kPrxYw/HJHhwu1z2PyBpnMLCNQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/json" "^1.0.0"
+
+"@codemirror/language@^6.0.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.2.0.tgz#f8d103927bb61346e93781b1ca7d3f4ac3c9280b"
+  integrity sha512-tabB0Ef/BflwoEmTB4a//WZ9P90UQyne9qWB9YFsmeS4bnEqSys7UpGk/da1URMXhyfuzWCwp+AQNMhvu8SfnA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.0.0.tgz#a249b021ac9933b94fe312d994d220f0ef11a157"
+  integrity sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.0.0.tgz#43bd6341d9aff18869386d2fce27519850e919e3"
+  integrity sha512-rL0rd3AhI0TAsaJPUaEwC63KHLO7KL0Z/dYozXj6E7L3wNHRyx7RfE0/j5HsIf912EE5n2PCb4Vg0rGYmDv4UQ==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.0.tgz#c0f1d80f61908c9dcf5e2a3fe931e9dd78f3df8a"
+  integrity sha512-qbUr94DZTe6/V1VS7LDLz11rM/1t/nJxR1El4I6UaxDEdc0aZZvq6JCLJWiRmUf95NRAnDH6fhXn+PWp9wGCIg==
+
+"@codemirror/theme-one-dark@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/theme-one-dark/-/theme-one-dark-6.0.0.tgz#81a999a568217f68522bd8846cbf7210ca2a59df"
+  integrity sha512-jTCfi1I8QT++3m21Ui6sU8qwu3F/hLv161KLxfvkV1cYWSBwyUanmQFs89ChobQjBHi2x7s2k71wF9WYvE8fdw==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/highlight" "^1.0.0"
+
+"@codemirror/view@^6.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.0.3.tgz#c0f6cf5c66d76cbe64227717708a714338ac76a4"
+  integrity sha512-1gDBymhbx2DZzwnR/rNUu1LiQqjxBJtFiB+4uLR6tHQ6vKhTIwUsP5uZUQ7SM7JxVx3UihMynnTqjcsC+mczZg==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    style-mod "^4.0.0"
+    w3c-keyname "^2.2.4"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -1349,6 +1438,33 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@lezer/common@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.0.0.tgz#1c95ae53ec17706aa3cbcc88b52c23f22ed56096"
+  integrity sha512-ohydQe+Hb+w4oMDvXzs8uuJd2NoA3D8YDcLiuDsLqH+yflDTPEpgCsWI3/6rH5C3BAedtH1/R51dxENldQceEA==
+
+"@lezer/highlight@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.0.0.tgz#1dc82300f5d39fbd67ae1194b5519b4c381878d3"
+  integrity sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@lezer/json/-/json-1.0.0.tgz#848ad9c2c3e812518eb02897edd5a7f649e9c160"
+  integrity sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==
+  dependencies:
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/lr@^1.0.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.2.0.tgz#59aecafdbc15be63f918cf777f470dd17562f051"
+  integrity sha512-TgEpfm9br2SX8JwtwKT8HsQZKuFkLRg6g+IRxObk9nVKQLKnkP3oMh+QGcTBL9GQsfQ2ADtKPbj2iGSMf3ytiA==
+  dependencies:
+    "@lezer/common" "^1.0.0"
 
 "@mswjs/cookies@^0.2.0":
   version "0.2.0"
@@ -2092,6 +2208,29 @@
     "@typescript-eslint/types" "5.23.0"
     eslint-visitor-keys "^3.0.0"
 
+"@uiw/codemirror-extensions-basic-setup@4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.11.4.tgz#c749a66980e18ca6651488712ea3239c82a31cdd"
+  integrity sha512-pc9pQtCQFmAH5nV9UmX37VB0+yzSFQ2kbSvLHBFST9siYnacaR6HxmkBBBbYYXwVK/n9pGZ6A8ZefAUNTFfo/A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
+"@uiw/react-codemirror@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@uiw/react-codemirror/-/react-codemirror-4.11.4.tgz#76adc757baa0b8b1a9bd30d7081f5622b896d607"
+  integrity sha512-p7DNBI6kj+DUzTe7MjBJwZ3qo0nSOav7T0MEGRpRNZA9ZO3RnzhPMie6swDA8e3dz1s59l9UdFB1fgyam1vFhQ==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@codemirror/theme-one-dark" "^6.0.0"
+    "@uiw/codemirror-extensions-basic-setup" "4.11.4"
+    codemirror "^6.0.0"
+
 "@vitejs/plugin-react@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz#2fcf0b6ce9bcdcd4cec5c760c199779d5657ece1"
@@ -2723,6 +2862,19 @@ clsx@^1.1.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
 
+codemirror@^6.0.0, codemirror@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.1.tgz#62b91142d45904547ee3e0e0e4c1a79158035a29"
+  integrity sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -2873,6 +3025,11 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+crelt@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
+  integrity sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
@@ -5755,6 +5912,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+style-mod@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
+  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
 stylis@4.0.13:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
@@ -6139,6 +6301,11 @@ w3c-hr-time@^1.0.2:
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   dependencies:
     browser-process-hrtime "^1.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.4.tgz#4ade6916f6290224cdbd1db8ac49eab03d0eef6b"
+  integrity sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==
 
 w3c-xmlserializer@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This contains fixes and improvements to the new playground feature:
* The playground will now search for feature toggles automatically if the URL contains a valid query
* The playground defaults to the first available valid environment
* Moved context form above the JSON field
* Fixed a bug where placeholder would display in search
* Changed the layout to keep the results on the side
* Added date input for currentTime and legal values dropdown
* Added sticky form
* Added variant popover information
* Added ability to search for isEnabled result
* Added CodeMirror JSON editor