### PR TITLE
Fix: Refetch immutable toggle when adding strategy

### DIFF
--- a/src/component/common/PercentageCircle/PercentageCircle.tsx
+++ b/src/component/common/PercentageCircle/PercentageCircle.tsx
@@ -5,12 +5,14 @@ interface IPercentageCircleProps {
     percentage: number;
     secondaryPieColor?: string;
     className?: string;
+    hideNumber?: boolean;
 }
 
 const PercentageCircle = ({
     styles,
     percentage,
     secondaryPieColor,
+    hideNumber,
     ...rest
 }: IPercentageCircleProps) => {
     const theme = useTheme();
@@ -35,9 +37,10 @@ const PercentageCircle = ({
                     display: 'flex',
                     justifyContent: 'center',
                     alignItems: 'center',
+                    fontSize: '12px',
                 }}
             >
-                100%
+                {hideNumber ? null : '100%'}
             </div>
         );
     }

--- a/src/component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty.tsx
+++ b/src/component/feature/FeatureStrategy/FeatureStrategyEmpty/FeatureStrategyEmpty.tsx
@@ -8,6 +8,7 @@ import { FeatureStrategyMenu } from '../FeatureStrategyMenu/FeatureStrategyMenu'
 import { PresetCard } from './PresetCard/PresetCard';
 import { useStyles } from './FeatureStrategyEmpty.styles';
 import { formatUnknownError } from 'utils/formatUnknownError';
+import { useFeatureImmutable } from 'hooks/api/getters/useFeature/useFeatureImmutable';
 
 interface IFeatureStrategyEmptyProps {
     projectId: string;
@@ -24,9 +25,15 @@ export const FeatureStrategyEmpty = ({
     const { addStrategyToFeature } = useFeatureStrategyApi();
     const { setToastData, setToastApiError } = useToast();
     const { refetchFeature } = useFeature(projectId, featureId);
+    const { refetchFeature: refetchFeatureImmutable } = useFeatureImmutable(
+        projectId,
+        featureId
+    );
 
     const onAfterAddStrategy = () => {
         refetchFeature();
+        refetchFeatureImmutable();
+
         setToastData({
             title: 'Strategy created',
             text: 'Successfully created strategy',

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyExecution/StrategyExecution.tsx
@@ -50,6 +50,7 @@ export const StrategyExecution = ({ strategy }: IStrategyExecutionProps) => {
                             sx={{ display: 'flex', alignItems: 'center' }}
                         >
                             <PercentageCircle
+                                hideNumber
                                 percentage={parseParameterNumber(
                                     parameters[key]
                                 )}


### PR DESCRIPTION
- Fix a bug where it's not possible to edit a quickly added strategy, because of cached form data.
- Fix style of gradual rollout percentage indicator