### PR TITLE
Copy a strategy between environments

### DIFF
--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/EnvironmentAccordionBody.tsx
@@ -14,11 +14,13 @@ import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
 interface IEnvironmentAccordionBodyProps {
     isDisabled: boolean;
     featureEnvironment?: IFeatureEnvironment;
+    otherEnvironments?: IFeatureEnvironment['name'][];
 }
 
 const EnvironmentAccordionBody = ({
     featureEnvironment,
     isDisabled,
+    otherEnvironments,
 }: IEnvironmentAccordionBodyProps) => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
@@ -93,6 +95,7 @@ const EnvironmentAccordionBody = ({
                                     strategy={strategy}
                                     index={index}
                                     environmentName={featureEnvironment.name}
+                                    otherEnvironments={otherEnvironments}
                                 />
                             ))}
                         </>

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyDraggableItem.tsx
@@ -1,6 +1,7 @@
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
 import { StrategySeparator } from 'component/common/StrategySeparator/StrategySeparator';
 import { MoveListItem, useDragItem } from 'hooks/useDragItem';
+import { IFeatureEnvironment } from 'interfaces/featureToggle';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import { StrategyItem } from './StrategyItem/StrategyItem';
 
@@ -8,6 +9,7 @@ interface IStrategyDraggableItemProps {
     strategy: IFeatureStrategy;
     environmentName: string;
     index: number;
+    otherEnvironments?: IFeatureEnvironment['name'][];
     onDragAndDrop: MoveListItem;
 }
 
@@ -15,6 +17,7 @@ export const StrategyDraggableItem = ({
     strategy,
     index,
     environmentName,
+    otherEnvironments,
     onDragAndDrop,
 }: IStrategyDraggableItemProps) => {
     const ref = useDragItem(index, onDragAndDrop);
@@ -28,6 +31,7 @@ export const StrategyDraggableItem = ({
             <StrategyItem
                 strategy={strategy}
                 environmentId={environmentName}
+                otherEnvironments={otherEnvironments}
                 isDraggable
             />
         </div>

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -1,0 +1,59 @@
+import { MouseEvent, useState, VFC } from 'react';
+import { IconButton, Menu, MenuItem, Tooltip } from '@mui/material';
+import { AddToPhotos as CopyIcon } from '@mui/icons-material';
+import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
+import { IFeatureEnvironment } from 'interfaces/featureToggle';
+
+interface ICopyStrategyIconMenuProps {
+    environments: IFeatureEnvironment['name'][];
+}
+
+export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
+    environments,
+}) => {
+    const projectId = useRequiredPathParam('projectId');
+    const featureId = useRequiredPathParam('featureId');
+    // TODO: strategy details
+    /// TODO: permissions
+    // TODO: API
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const open = Boolean(anchorEl);
+    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <div>
+            <Tooltip title="Copy to another environment">
+                <IconButton
+                    size="large"
+                    id="basic-button"
+                    aria-controls={open ? 'basic-menu' : undefined}
+                    aria-haspopup="true"
+                    aria-expanded={open ? 'true' : undefined}
+                    onClick={handleClick}
+                >
+                    <CopyIcon />
+                </IconButton>
+            </Tooltip>
+            <Menu
+                id="basic-menu"
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleClose}
+                MenuListProps={{
+                    'aria-labelledby': 'basic-button',
+                }}
+            >
+                {environments.map(environment => (
+                    <MenuItem key={environment} onClick={handleClose}>
+                        {environment}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </div>
+    );
+};

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -47,7 +47,6 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
         setAnchorEl(null);
     };
     const { hasAccess } = useContext(AccessContext);
-
     const onClick = async (environmentId: string) => {
         const { id, ...strategyCopy } = {
             ...strategy,
@@ -74,19 +73,30 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
         handleClose();
     };
 
+    const enabled = environments.some(environment =>
+        hasAccess(CREATE_FEATURE_STRATEGY, projectId, environment)
+    );
+
     return (
         <div>
-            <Tooltip title="Copy to another environment">
-                <IconButton
-                    size="large"
-                    id="basic-button"
-                    aria-controls={open ? 'basic-menu' : undefined}
-                    aria-haspopup="true"
-                    aria-expanded={open ? 'true' : undefined}
-                    onClick={handleClick}
-                >
-                    <CopyIcon />
-                </IconButton>
+            <Tooltip
+                title={`Copy to another environment${
+                    enabled ? '' : ' (Access denied)'
+                }`}
+            >
+                <div>
+                    <IconButton
+                        size="large"
+                        id="basic-button"
+                        aria-controls={open ? 'basic-menu' : undefined}
+                        aria-haspopup="true"
+                        aria-expanded={open ? 'true' : undefined}
+                        onClick={handleClick}
+                        disabled={!enabled}
+                    >
+                        <CopyIcon />
+                    </IconButton>
+                </div>
             </Tooltip>
             <Menu
                 id="basic-menu"

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/CopyStrategyIconMenu/CopyStrategyIconMenu.tsx
@@ -1,28 +1,77 @@
-import { MouseEvent, useState, VFC } from 'react';
-import { IconButton, Menu, MenuItem, Tooltip } from '@mui/material';
-import { AddToPhotos as CopyIcon } from '@mui/icons-material';
+import { MouseEvent, useContext, useState, VFC } from 'react';
+import {
+    IconButton,
+    ListItemIcon,
+    ListItemText,
+    Menu,
+    MenuItem,
+    Tooltip,
+} from '@mui/material';
+import { AddToPhotos as CopyIcon, Lock } from '@mui/icons-material';
+import { IFeatureStrategy } from 'interfaces/strategy';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { IFeatureEnvironment } from 'interfaces/featureToggle';
+import AccessContext from 'contexts/AccessContext';
+import { CREATE_FEATURE_STRATEGY } from 'component/providers/AccessProvider/permissions';
+import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { useFeature } from 'hooks/api/getters/useFeature/useFeature';
+import useFeatureStrategyApi from 'hooks/api/actions/useFeatureStrategyApi/useFeatureStrategyApi';
+import useToast from 'hooks/useToast';
+import { useFeatureImmutable } from 'hooks/api/getters/useFeature/useFeatureImmutable';
+import { formatUnknownError } from 'utils/formatUnknownError';
 
 interface ICopyStrategyIconMenuProps {
     environments: IFeatureEnvironment['name'][];
+    strategy: IFeatureStrategy;
 }
 
 export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
     environments,
+    strategy,
 }) => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
-    // TODO: strategy details
-    /// TODO: permissions
-    // TODO: API
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
+    const { addStrategyToFeature } = useFeatureStrategyApi();
+    const { setToastData, setToastApiError } = useToast();
+    const { refetchFeature } = useFeature(projectId, featureId);
+    const { refetchFeature: refetchFeatureImmutable } = useFeatureImmutable(
+        projectId,
+        featureId
+    );
     const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
         setAnchorEl(event.currentTarget);
     };
     const handleClose = () => {
         setAnchorEl(null);
+    };
+    const { hasAccess } = useContext(AccessContext);
+
+    const onClick = async (environmentId: string) => {
+        const { id, ...strategyCopy } = {
+            ...strategy,
+            environment: environmentId,
+        };
+
+        try {
+            await addStrategyToFeature(
+                projectId,
+                featureId,
+                environmentId,
+                strategyCopy
+            );
+            refetchFeature();
+            refetchFeatureImmutable();
+            setToastData({
+                title: `Strategy created`,
+                text: `Successfully copied a strategy to ${environmentId}`,
+                type: 'success',
+            });
+        } catch (error) {
+            setToastApiError(formatUnknownError(error));
+        }
+        handleClose();
     };
 
     return (
@@ -48,11 +97,41 @@ export const CopyStrategyIconMenu: VFC<ICopyStrategyIconMenuProps> = ({
                     'aria-labelledby': 'basic-button',
                 }}
             >
-                {environments.map(environment => (
-                    <MenuItem key={environment} onClick={handleClose}>
-                        {environment}
-                    </MenuItem>
-                ))}
+                {environments.map(environment => {
+                    const access = hasAccess(
+                        CREATE_FEATURE_STRATEGY,
+                        projectId,
+                        environment
+                    );
+
+                    return (
+                        <Tooltip
+                            title={
+                                access
+                                    ? ''
+                                    : "You don't have access to add a strategy to this environment"
+                            }
+                            key={environment}
+                        >
+                            <div>
+                                <MenuItem
+                                    onClick={() => onClick(environment)}
+                                    disabled={!access}
+                                >
+                                    <ConditionallyRender
+                                        condition={!access}
+                                        show={
+                                            <ListItemIcon>
+                                                <Lock fontSize="small" />
+                                            </ListItemIcon>
+                                        }
+                                    />
+                                    <ListItemText>{environment}</ListItemText>
+                                </MenuItem>
+                            </div>
+                        </Tooltip>
+                    );
+                })}
             </Menu>
         </div>
     );

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyItem.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyItem.tsx
@@ -78,6 +78,7 @@ export const StrategyItem = ({
                         show={() => (
                             <CopyStrategyIconMenu
                                 environments={otherEnvironments as string[]}
+                                strategy={strategy}
                             />
                         )}
                     />

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyItem.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/EnvironmentAccordionBody/StrategyDraggableItem/StrategyItem/StrategyItem.tsx
@@ -1,6 +1,7 @@
 import { DragIndicator, Edit } from '@mui/icons-material';
 import { styled, useTheme, IconButton } from '@mui/material';
 import { Link } from 'react-router-dom';
+import { IFeatureEnvironment } from 'interfaces/featureToggle';
 import { IFeatureStrategy } from 'interfaces/strategy';
 import {
     getFeatureStrategyIcon,
@@ -13,13 +14,15 @@ import { FeatureStrategyRemove } from 'component/feature/FeatureStrategy/Feature
 import StringTruncator from 'component/common/StringTruncator/StringTruncator';
 import { useRequiredPathParam } from 'hooks/useRequiredPathParam';
 import { StrategyExecution } from './StrategyExecution/StrategyExecution';
-import { useStyles } from './StrategyItem.styles';
 import { ConditionallyRender } from 'component/common/ConditionallyRender/ConditionallyRender';
+import { CopyStrategyIconMenu } from './CopyStrategyIconMenu/CopyStrategyIconMenu';
+import { useStyles } from './StrategyItem.styles';
 
 interface IStrategyItemProps {
     environmentId: string;
     strategy: IFeatureStrategy;
     isDraggable?: boolean;
+    otherEnvironments?: IFeatureEnvironment['name'][];
 }
 
 const DragIcon = styled(IconButton)(({ theme }) => ({
@@ -32,6 +35,7 @@ export const StrategyItem = ({
     environmentId,
     strategy,
     isDraggable,
+    otherEnvironments,
 }: IStrategyItemProps) => {
     const projectId = useRequiredPathParam('projectId');
     const featureId = useRequiredPathParam('featureId');
@@ -67,6 +71,16 @@ export const StrategyItem = ({
                     text={formatStrategyName(strategy.name)}
                 />
                 <div className={styles.actions}>
+                    <ConditionallyRender
+                        condition={Boolean(
+                            otherEnvironments && otherEnvironments?.length > 0
+                        )}
+                        show={() => (
+                            <CopyStrategyIconMenu
+                                environments={otherEnvironments as string[]}
+                            />
+                        )}
+                    />
                     <PermissionIconButton
                         permission={UPDATE_FEATURE_STRATEGY}
                         environmentId={environmentId}

--- a/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
+++ b/src/component/feature/FeatureView/FeatureOverview/FeatureOverviewEnvironments/FeatureOverviewEnvironment/FeatureOverviewEnvironment.tsx
@@ -126,6 +126,9 @@ const FeatureOverviewEnvironment = ({
                     <EnvironmentAccordionBody
                         featureEnvironment={featureEnvironment}
                         isDisabled={!env.enabled}
+                        otherEnvironments={feature?.environments
+                            .map(({ name }) => name)
+                            .filter(name => name !== env.name)}
                     />
                     <ConditionallyRender
                         condition={


### PR DESCRIPTION
<img width="455" alt="Untitled" src="https://user-images.githubusercontent.com/2625371/181511957-d7d9a638-2c28-40d9-9041-bb8bbf43f742.png">

On single feature page, adds a button with a menu that enables quick access to copying a strategy to another environment of the same toggle.