### PR TITLE
chore: remove unused codemirror deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,9 +103,7 @@
     "vitest": "0.20.3",
     "whatwg-fetch": "^3.6.2",
     "@codemirror/lang-json": "6.0.0",
-    "@codemirror/state": "6.1.1",
-    "@uiw/react-codemirror": "^4.11.4",
-    "codemirror": "^6.0.1"
+    "@uiw/react-codemirror": "^4.11.4"
   },
   "jest": {
     "moduleNameMapper": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,11 +1318,6 @@
     "@codemirror/view" "^6.0.0"
     crelt "^1.0.5"
 
-"@codemirror/state@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.1.tgz#4f512e5e34ea23a5e10b2c1fe43f6195e90417bb"
-  integrity sha512-2s+aXsxmAwnR3Rd+JDHPG/1lw0YsA9PEwl7Re88gHJHGfxyfEzKBmsN4rr53RyPIR4lzbbhJX0DCq0WlqlBIRw==
-
 "@codemirror/state@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.0.tgz#c0f1d80f61908c9dcf5e2a3fe931e9dd78f3df8a"
@@ -3027,7 +3022,7 @@ clsx@^1.2.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
-codemirror@^6.0.0, codemirror@^6.0.1:
+codemirror@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.1.tgz#62b91142d45904547ee3e0e0e4c1a79158035a29"
   integrity sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==


### PR DESCRIPTION
* There seems to be a conflict in dependencies that causes an issue in the initialization of codemirror. This PR aims to remove unused deps that may conflict. 

See https://github.com/uiwjs/react-codemirror/issues/216

Related to: https://github.com/Unleash/unleash/issues/1873

